### PR TITLE
Use ETag for static files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rustc-serialize = "0.3"
 term = "0.2"
 time = "0.1.31"
 url = "0.2"
+filetime = "0.1.10"
 
 [dev-dependencies]
 mustache = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,14 @@ documentation = "http://tomaka.github.io/rouille/rouille/index.html"
 description = "High-level web framework"
 
 [dependencies]
+filetime = "0.1.10"
 multipart = { version = "0.5.1", default-features = false, features = ["server"] }
-tiny_http = "0.5.0"
 rand = "0.3.11"
 rustc-serialize = "0.3"
 term = "0.2"
 time = "0.1.31"
+tiny_http = "0.5.0"
 url = "0.2"
-filetime = "0.1.10"
 
 [dev-dependencies]
 mustache = "0.6"

--- a/doc/book/README.md
+++ b/doc/book/README.md
@@ -5,7 +5,7 @@ Welcome the *rouille* library!
 *Rouille* is a micro-web-framework that is built around the following concept:
 don't do anything magical.
 
-With the exception of the handling of the HTTP protocole, you know *exactly* what is happening
+With the exception of the handling of the HTTP protocol, you know *exactly* what is happening
 at any time.
 Each instruction is executed one after another. There is no callback, no middleware, no filter
 that intercepts and changes your data without telling you. If your website doesn't give the

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -7,6 +7,9 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+extern crate filetime;
+extern crate time;
+
 use std::fs;
 use std::path::Path;
 
@@ -77,11 +80,33 @@ pub fn match_assets<P: ?Sized>(request: &Request, path: &P) -> Result<Response, 
         Err(_) => return Err(RouteError::NoRouteFound)
     };
 
+    let etag: u64 = fs::metadata(&potential_file)
+        .map(|meta| filetime::FileTime::from_last_modification_time(&meta).seconds_relative_to_1970())
+        .unwrap_or(time::now().tm_nsec as u64)
+        ^ 0xd3f40305c9f8e911u64;
+
+    let not_modified: bool = request.header("If-None-Match")
+        .and_then(|t| t.parse::<u64>().ok())
+        .map(|req_etag| req_etag == etag)
+        .unwrap_or(false);
+
+    if not_modified {
+        return Ok(Response {
+            status_code: 304,
+            headers: vec![
+                ("Cache-Control".to_owned(), "public, max-age=3600".to_owned()),
+                ("etag".to_owned(), etag.to_string())
+            ],
+            data: ResponseBody::empty()
+        })
+    }
+
     Ok(Response {
         status_code: 200,
         headers: vec![
             ("Cache-Control".to_owned(), "public, max-age=3600".to_owned()),
-            ("Content-Type".to_owned(), extension_to_mime(extension).to_owned())
+            ("Content-Type".to_owned(), extension_to_mime(extension).to_owned()),
+            ("etag".to_owned(), etag.to_string())
         ],
         data: ResponseBody::from_file(file),
     })

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -7,11 +7,11 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-extern crate filetime;
-extern crate time;
-
 use std::fs;
 use std::path::Path;
+
+use filetime;
+use time;
 
 use Request;
 use Response;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![deny(unsafe_code)]
 
+extern crate filetime;
 extern crate multipart;
 extern crate rand;
 extern crate rustc_serialize;


### PR DESCRIPTION
This means that if the static file has not changed (since the last time the browser requested it) it will not download new data. See https://en.wikipedia.org/wiki/HTTP_ETag

Tested locally (returns 304 on soft refresh).

This adds [filetime](http://alexcrichton.com/filetime/filetime/index.html) as a dependency which is used to get the last modification time of the file, which is then used (xor-ed with a randomly generated u64) as the etag value.