### PR TITLE
Avoid cloning the request data

### DIFF
--- a/src/input/json.rs
+++ b/src/input/json.rs
@@ -71,7 +71,7 @@ pub fn get_json_input<O>(request: &Request) -> Result<O, JsonError> where O: Dec
         return Err(JsonError::WrongContentType);
     }
 
-    let content = try!(String::from_utf8(request.data()));
+    let content = try!(String::from_utf8(request.data().to_vec()));
     let data = try!(json::decode(&content));
     Ok(data)
 }

--- a/src/input/multipart.rs
+++ b/src/input/multipart.rs
@@ -43,7 +43,7 @@ pub fn get_multipart_input(request: &Request) -> Result<Multipart, MultipartErro
     };
 
     Ok(Multipart {
-        inner: InnerMultipart::with_body(Cursor::new(request.data()), boundary)
+        inner: InnerMultipart::with_body(Cursor::new(request.data().to_vec()), boundary)
     })
 }
 
@@ -77,4 +77,3 @@ fn multipart_boundary(request: &Request) -> Option<String> {
     let end = content_type[start..].find(';').map_or(content_type.len(), |end| start + end);
     Some(content_type[start .. end].to_owned())
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,7 +482,7 @@ impl<'a> Request<'a> {
 
     /// UNSTABLE. Returns the body of the request.
     ///
-    /// Will eventually return an object that implements `Read` instead of a `Vec<u8>`.
+    /// Will eventually return an object that implements `Read` instead of a `&[u8]`.
     pub fn data(&self) -> &[u8] {
         &self.data
     }


### PR DESCRIPTION
Hello. I noticed that the data from a request was cloned a few places. So this is a suggestion for a change to avoid the clones when not needed. This includes a backward incompatible change to the API, but I think its worth it.

* Backwards incompatible: Return &[u8] instead of Vec<u8> from Request::data().
  If a vec is needed downstream, its easy to call data().to_vec(), and the
  copying is therefore only done when needed. For example serde can serialize
  directly from a &[u8], and we eliminate a clone
* Data is Cow<'a, [u8]> instead of Vec<u8>. Therefore it can be either a Vec<u8>
  or a &[u8]. This elimniate cloning of data from Request::remove_prefix()