### PR TITLE
Remove `RouteError`

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -8,24 +8,25 @@ fn main() {
         let _entry = rouille::LogEntry::start(io::stdout(), request);
 
         if let Some(request) = request.remove_prefix("/examples") {
-            if let Ok(r) = rouille::match_assets(&request, "examples") {
-                return r;
+            let response = rouille::match_assets(&request, "examples");
+            if response.success() {
+                return response;
             }
         }
 
-        let response = router!(request,
+        router!(request,
             (GET) (/) => {
-                Ok(rouille::Response::redirect("/hello/world"))
+                rouille::Response::redirect("/hello/world")
             },
 
             (GET) (/hello/world) => {
                 println!("hello world");
-                Ok(rouille::Response::text("hello world"))
+                rouille::Response::text("hello world")
             },
 
             (GET) (/hello-world) => {
                 println!("hello-world");
-                Ok(rouille::Response::text("hello world"))
+                rouille::Response::text("hello world")
             },
 
             (GET) (/panic) => {
@@ -34,17 +35,15 @@ fn main() {
 
             (GET) (/{id: u32}) => {
                 println!("u32 {:?}", id);
-                Err(rouille::RouteError::WrongInput)
+                rouille::Response::empty_400()
             },
 
             (GET) (/{id: String}) => {
                 println!("String {:?}", id);
-                Ok(rouille::Response::text(format!("hello, {}", id)))
+                rouille::Response::text(format!("hello, {}", id))
             },
 
-            _ => Err(rouille::RouteError::NoRouteFound)
-        );
-
-        response.unwrap_or_else(|err| rouille::Response::from_error(&err))
+            _ => rouille::Response::empty_404()
+        )
     });
 }

--- a/examples/multipart.rs
+++ b/examples/multipart.rs
@@ -9,9 +9,9 @@ fn main() {
     rouille::start_server("localhost:8001", move |request| {
         let _entry = rouille::LogEntry::start(io::stdout(), request);
 
-        let response = (|| router!(request,
+        router!(request,
             (GET) (/) => {
-                Ok(rouille::Response::html(FORM))
+                rouille::Response::html(FORM)
             },
 
             (POST) (/submit) => {
@@ -31,13 +31,11 @@ fn main() {
                     }
                 }
 
-                Ok(rouille::Response::html(FORM))
+                rouille::Response::html(FORM)
             },
 
-            _ => Err(rouille::RouteError::NoRouteFound)
-        ))();
-
-        response.unwrap_or_else(|err| rouille::Response::from_error(&err))
+            _ => rouille::Response::empty_404()
+        )
     });
 }
 

--- a/examples/simple_form.rs
+++ b/examples/simple_form.rs
@@ -12,26 +12,24 @@ fn main() {
     rouille::start_server("localhost:8000", move |request| {
         let _entry = rouille::LogEntry::start(io::stdout(), request);
 
-        let response = (|| router!(request,
+        router!(request,
             (GET) (/) => {
                 let mut output = Vec::new();
                 form.render_data(&mut output, &mustache::Data::Bool(false));
-                Ok(rouille::Response::html(output))
+                rouille::Response::html(output)
             },
 
             (POST) (/submit) => {
-                let data: FormData = try!(rouille::input::get_post_input(request));
+                let data: FormData = try_or_400!(rouille::input::get_post_input(request));
                 println!("{:?}", data);
 
                 let mut output = Vec::new();
                 form_success.render(&mut output, &data);
-                Ok(rouille::Response::html(output))
+                rouille::Response::html(output)
             },
 
-            _ => Err(rouille::RouteError::NoRouteFound)
-        ))();
-
-        response.unwrap_or_else(|err| rouille::Response::from_error(&err))
+            _ => rouille::Response::empty_404()
+        )
     });
 }
 

--- a/src/find_route.rs
+++ b/src/find_route.rs
@@ -8,38 +8,38 @@
 // according to those terms.
 
 /// Evaluates each parameter until one of them evaluates to something else
-/// than `Err(RouteError::NoRouteFound)`.
+/// than a 404 error code.
 ///
-/// This macro supposes that each route returns a `Result<_, RouteError>`.
+/// This macro supposes that each route returns a `Response`.
 ///
 /// # Example
 ///
 /// ```no_run
 /// # #[macro_use] extern crate rouille;
 /// # fn main() {
-/// use rouille::{Request, Response, RouteError};
+/// use rouille::{Request, Response};
 ///
-/// fn handle_request_a(_: &Request) -> Result<Response, RouteError> {
+/// fn handle_request_a(_: &Request) -> Response {
 /// # panic!()
 ///    // ...
 /// }
 ///
-/// fn handle_request_b(_: &Request) -> Result<Response, RouteError> {
+/// fn handle_request_b(_: &Request) -> Response {
 /// # panic!()
 ///    // ...
 /// }
 ///
-/// fn handle_request_c(_: &Request) -> Result<Response, RouteError> {
+/// fn handle_request_c(_: &Request) -> Response {
 /// # panic!()
 ///    // ...
 /// }
 ///
 /// # let request = unsafe { ::std::mem::uninitialized() };
-/// // First calls `handle_request_a`. If it returns anything else than `NoRouteFound`, then the
+/// // First calls `handle_request_a`. If it returns anything else than a 404 error, then the
 /// // `response` will contain the return value.
 /// //
-/// // Instead if `handle_request_a` returned `NoRouteFound`, then `handle_request_b` is tried.
-/// // If `handle_request_b` also returns `NoRouteFound`, then `handle_request_c` is tried.
+/// // Instead if `handle_request_a` returned a 404 error, then `handle_request_b` is tried.
+/// // If `handle_request_b` also returns a 404 error, then `handle_request_c` is tried.
 /// let response = find_route!(
 ///     handle_request_a(request),
 ///     handle_request_b(request),
@@ -51,9 +51,9 @@
 #[macro_export]
 macro_rules! find_route {
     ($($handler:expr),+) => ({
-        let mut response = Err($crate::RouteError::NoRouteFound);
+        let mut response = $crate::Response::empty_404();
         $(
-            if let Err($crate::RouteError::NoRouteFound) = response {
+            if response.status_code == 404 {
                 response = $handler;
             }
         )+

--- a/src/input/json.rs
+++ b/src/input/json.rs
@@ -46,10 +46,10 @@ impl From<json::DecoderError> for JsonError {
 /// ```
 /// extern crate rustc_serialize;
 /// # #[macro_use] extern crate rouille;
-/// # use rouille::{Request, Response, RouteError};
+/// # use rouille::{Request, Response};
 /// # fn main() {}
 ///
-/// fn route_handler(request: &Request) -> Result<Response, RouteError> {
+/// fn route_handler(request: &Request) -> Response {
 ///     #[derive(RustcDecodable)]
 ///     struct Json {
 ///         field1: String,
@@ -57,7 +57,7 @@ impl From<json::DecoderError> for JsonError {
 ///     }
 /// 
 ///     let json: Json = try_or_400!(rouille::input::get_json_input(request));
-///     Ok(Response::text(format!("field1's value is {}", json.field1)))
+///     Response::text(format!("field1's value is {}", json.field1))
 /// }
 /// ```
 ///

--- a/src/input/multipart.rs
+++ b/src/input/multipart.rs
@@ -8,7 +8,6 @@
 // according to those terms.
 
 use Request;
-use RouteError;
 
 use std::io::Cursor;
 use std::mem;
@@ -26,13 +25,6 @@ pub enum MultipartError {
     /// The `Content-Type` header of the request indicates that it doesn't contain multipart data
     /// or is invalid.
     WrongContentType,
-}
-
-impl From<MultipartError> for RouteError {
-    #[inline]
-    fn from(err: MultipartError) -> RouteError {
-        RouteError::WrongInput
-    }
 }
 
 /// Attempts to decode the content of the request as `multipart/form-data` data.

--- a/src/input/post.rs
+++ b/src/input/post.rs
@@ -11,7 +11,6 @@ use rustc_serialize::Decoder;
 use rustc_serialize::Decodable;
 
 use Request;
-use RouteError;
 
 use std::mem;
 use std::num;
@@ -38,13 +37,6 @@ pub enum PostError {
 
     /// Failed to parse a string field.
     NotUtf8(String),
-}
-
-impl From<PostError> for RouteError {
-    #[inline]
-    fn from(err: PostError) -> RouteError {
-        RouteError::WrongInput
-    }
 }
 
 impl From<ParseBoolError> for PostError {
@@ -80,10 +72,10 @@ impl From<num::ParseFloatError> for PostError {
 /// ```
 /// extern crate rustc_serialize;
 /// # #[macro_use] extern crate rouille;
-/// # use rouille::{Request, Response, RouteError};
+/// # use rouille::{Request, Response};
 /// # fn main() {}
 ///
-/// fn route_handler(request: &Request) -> Result<Response, RouteError> {
+/// fn route_handler(request: &Request) -> Response {
 ///     #[derive(RustcDecodable)]
 ///     struct FormData {
 ///         field1: u32,
@@ -91,7 +83,7 @@ impl From<num::ParseFloatError> for PostError {
 ///     }
 ///
 ///     let data: FormData = try_or_400!(rouille::input::get_post_input(&request));
-///     Ok(Response::text(format!("field1's value is {}", data.field1)))
+///     Response::text(format!("field1's value is {}", data.field1))
 /// }
 /// ```
 ///

--- a/src/response.rs
+++ b/src/response.rs
@@ -13,8 +13,6 @@ use std::io::Read;
 use std::fs::File;
 use rustc_serialize;
 
-use RouteError;
-
 /// Contains a prototype of a response.
 /// The response is only sent when you call `Request::respond`.
 pub struct Response {
@@ -33,31 +31,18 @@ pub struct Response {
 }
 
 impl Response {
-    /// UNSTABLE. Builds a default response to handle the given route error.
+    /// Returns true if the status code of this `Response` indicates success.
     ///
-    /// Important: don't use this in a real website. This function is just a convenience when
-    /// prototyping.
-    ///
-    /// For authentication-related errors, you are strongly encouraged to handle them yourself.
+    /// This is the range [200-399].
     #[inline]
-    pub fn from_error(err: &RouteError) -> Response {
-        match err {
-            &RouteError::NoRouteFound => Response {
-                status_code: 404, headers: vec![], data: ResponseBody::empty()
-            },
-            &RouteError::WrongInput => Response {
-                status_code: 400, headers: vec![], data: ResponseBody::empty()
-            },
-            &RouteError::LoginRequired => Response {
-                status_code: 401, headers: vec![], data: ResponseBody::empty()
-            },     // TODO: www-auth header?
-            &RouteError::WrongLoginPassword => Response {
-                status_code: 401, headers: vec![], data: ResponseBody::empty()
-            },     // TODO: www-auth header?
-            &RouteError::NotAuthorized => Response {
-                status_code: 403, headers: vec![], data: ResponseBody::empty()
-            },
-        }
+    pub fn success(&self) -> bool {
+        self.status_code >= 200 && self.status_code < 400
+    }
+
+    /// Shortcut for `!response.success()`.
+    #[inline]
+    pub fn error(&self) -> bool {
+        !self.success()
     }
 
     /// Builds a `Response` that redirects the user to another URL with a 303 status code.
@@ -111,6 +96,26 @@ impl Response {
             status_code: 401,
             headers: vec![("WWW-Authenticate".to_owned(), format!("Basic realm=\"{}\"", realm))],
             data: ResponseBody::empty(),
+        }
+    }
+
+    /// Builds an empty `Response` with a 400 status code.
+    #[inline]
+    pub fn empty_400() -> Response {
+        Response {
+            status_code: 400,
+            headers: vec![],
+            data: ResponseBody::empty()
+        }
+    }
+
+    /// Builds an empty `Response` with a 404 status code.
+    #[inline]
+    pub fn empty_404() -> Response {
+        Response {
+            status_code: 404,
+            headers: vec![],
+            data: ResponseBody::empty()
         }
     }
 


### PR DESCRIPTION
Close #26 

[breaking-change]

- Removes the `RouteError` enum.
- The helper macros `try_or_400`, `assert_or_400` and `find_route!` now assume that the function returns a `Response` instead of a `Result<_, RouteError>`.
- Adds `try_or_404!` similar to `try_or_400`.
- Adds `Response::empty_400()`, `Response::empty_404()`, `Response::success()` and `Response::error()`. The last two return a bool.
- `match_assets` now returns a `Response` instead of a `Result`.
