### PR TITLE
Rework logging

### DIFF
--- a/examples/git-http-backend.rs
+++ b/examples/git-http-backend.rs
@@ -10,16 +10,19 @@
 #[macro_use]
 extern crate rouille;
 
+use std::io;
 use std::env;
 use std::process::Command;
 use rouille::cgi::CgiRun;
 
 fn main() {
     rouille::start_server("localhost:8080", move |request| {
-        let mut cmd = Command::new("git");
-        cmd.arg("http-backend");
-        cmd.env("GIT_PROJECT_ROOT", env::current_dir().unwrap().to_str().unwrap());
-        cmd.env("GIT_HTTP_EXPORT_ALL", "");
-        cmd.start_cgi(&request).unwrap()
+        rouille::log(&request, io::stdout(), || {
+            let mut cmd = Command::new("git");
+            cmd.arg("http-backend");
+            cmd.env("GIT_PROJECT_ROOT", env::current_dir().unwrap().to_str().unwrap());
+            cmd.env("GIT_HTTP_EXPORT_ALL", "");
+            cmd.start_cgi(&request).unwrap()
+        })
     });
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -5,45 +5,45 @@ use std::io;
 
 fn main() {
     rouille::start_server("localhost:8000", move |request| {
-        let _entry = rouille::LogEntry::start(io::stdout(), request);
-
-        if let Some(request) = request.remove_prefix("/examples") {
-            let response = rouille::match_assets(&request, "examples");
-            if response.success() {
-                return response;
+        rouille::log(&request, io::stdout(), || {
+            if let Some(request) = request.remove_prefix("/examples") {
+                let response = rouille::match_assets(&request, "examples");
+                if response.success() {
+                    return response;
+                }
             }
-        }
 
-        router!(request,
-            (GET) (/) => {
-                rouille::Response::redirect("/hello/world")
-            },
+            router!(request,
+                (GET) (/) => {
+                    rouille::Response::redirect("/hello/world")
+                },
 
-            (GET) (/hello/world) => {
-                println!("hello world");
-                rouille::Response::text("hello world")
-            },
+                (GET) (/hello/world) => {
+                    println!("hello world");
+                    rouille::Response::text("hello world")
+                },
 
-            (GET) (/hello-world) => {
-                println!("hello-world");
-                rouille::Response::text("hello world")
-            },
+                (GET) (/hello-world) => {
+                    println!("hello-world");
+                    rouille::Response::text("hello world")
+                },
 
-            (GET) (/panic) => {
-                panic!("Oops!")
-            },
+                (GET) (/panic) => {
+                    panic!("Oops!")
+                },
 
-            (GET) (/{id: u32}) => {
-                println!("u32 {:?}", id);
-                rouille::Response::empty_400()
-            },
+                (GET) (/{id: u32}) => {
+                    println!("u32 {:?}", id);
+                    rouille::Response::empty_400()
+                },
 
-            (GET) (/{id: String}) => {
-                println!("String {:?}", id);
-                rouille::Response::text(format!("hello, {}", id))
-            },
+                (GET) (/{id: String}) => {
+                    println!("String {:?}", id);
+                    rouille::Response::text(format!("hello, {}", id))
+                },
 
-            _ => rouille::Response::empty_404()
-        )
+                _ => rouille::Response::empty_404()
+            )
+        })
     });
 }

--- a/examples/multipart.rs
+++ b/examples/multipart.rs
@@ -7,35 +7,35 @@ use std::io::Read;
 
 fn main() {
     rouille::start_server("localhost:8001", move |request| {
-        let _entry = rouille::LogEntry::start(io::stdout(), request);
+        rouille::log(&request, io::stdout(), || {
+            router!(request,
+                (GET) (/) => {
+                    rouille::Response::html(FORM)
+                },
 
-        router!(request,
-            (GET) (/) => {
-                rouille::Response::html(FORM)
-            },
+                (POST) (/submit) => {
+                    let mut multipart = rouille::input::multipart::get_multipart_input(&request)
+                                                                                            .unwrap();
 
-            (POST) (/submit) => {
-                let mut multipart = rouille::input::multipart::get_multipart_input(&request)
-                                                                                        .unwrap();
+                    while let Some(entry) = multipart.next() {
+                        println!("{:?}", entry.name);
 
-                while let Some(entry) = multipart.next() {
-                    println!("{:?}", entry.name);
-
-                    match entry.data {
-                        rouille::input::multipart::MultipartData::Text(txt) => println!("{:?}", txt),
-                        rouille::input::multipart::MultipartData::File(mut f) => {
-                            let mut data = Vec::new();
-                            f.read_to_end(&mut data).unwrap();
-                            println!("{:?}", data)
-                        },
+                        match entry.data {
+                            rouille::input::multipart::MultipartData::Text(txt) => println!("{:?}", txt),
+                            rouille::input::multipart::MultipartData::File(mut f) => {
+                                let mut data = Vec::new();
+                                f.read_to_end(&mut data).unwrap();
+                                println!("{:?}", data)
+                            },
+                        }
                     }
-                }
 
-                rouille::Response::html(FORM)
-            },
+                    rouille::Response::html(FORM)
+                },
 
-            _ => rouille::Response::empty_404()
-        )
+                _ => rouille::Response::empty_404()
+            )
+        })
     });
 }
 

--- a/examples/simple_form.rs
+++ b/examples/simple_form.rs
@@ -10,26 +10,26 @@ fn main() {
     let form_success = mustache::compile_path("./examples/assets/form_success.html.mustache").unwrap();
 
     rouille::start_server("localhost:8000", move |request| {
-        let _entry = rouille::LogEntry::start(io::stdout(), request);
+        rouille::log(&request, io::stdout(), || {
+            router!(request,
+                (GET) (/) => {
+                    let mut output = Vec::new();
+                    form.render_data(&mut output, &mustache::Data::Bool(false));
+                    rouille::Response::html(output)
+                },
 
-        router!(request,
-            (GET) (/) => {
-                let mut output = Vec::new();
-                form.render_data(&mut output, &mustache::Data::Bool(false));
-                rouille::Response::html(output)
-            },
+                (POST) (/submit) => {
+                    let data: FormData = try_or_400!(rouille::input::get_post_input(request));
+                    println!("{:?}", data);
 
-            (POST) (/submit) => {
-                let data: FormData = try_or_400!(rouille::input::get_post_input(request));
-                println!("{:?}", data);
+                    let mut output = Vec::new();
+                    form_success.render(&mut output, &data);
+                    rouille::Response::html(output)
+                },
 
-                let mut output = Vec::new();
-                form_success.render(&mut output, &data);
-                rouille::Response::html(output)
-            },
-
-            _ => rouille::Response::empty_404()
-        )
+                _ => rouille::Response::empty_404()
+            )
+        })
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ extern crate tiny_http;
 extern crate url;
 
 pub use assets::match_assets;
-pub use log::LogEntry;
+pub use log::log;
 pub use input::{SessionsManager, Session, generate_session_id};
 pub use response::{Response, ResponseBody};
 


### PR DESCRIPTION
[breaking-change]

Removes `LogEntry` and replaces it with a function named `log`.
The advantage is that the `log` function has access to the `Response`, contrary to `LogEntry`.
