### PR TITLE
Support for websockets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,10 @@ filetime = "0.1.10"
 multipart = { version = "0.5.1", default-features = false, features = ["server"] }
 rand = "0.3.11"
 rustc-serialize = "0.3"
+sha1 = "0.2.0"
 term = "0.2"
 time = "0.1.31"
-tiny_http = "0.5.0"
+tiny_http = "0.5.6"
 url = "1.2"
 
 [dev-dependencies]

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -1,0 +1,99 @@
+// Copyright (c) 2016 The Rouille developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+#[macro_use]
+extern crate rouille;
+
+use std::thread;
+
+use rouille::websocket;
+use rouille::Response;
+
+fn main() {
+    // This example demonstrates how to use websockets with rouille.
+
+    // Small message so that people don't need to read the source code.
+    // Note that like all examples we only listen on `localhost`, so you can't access this server
+    // from another machine than your own.
+    println!("Now listening on localhost:8000");
+
+    rouille::start_server("localhost:8000", move |request| {
+        router!(request,
+            (GET) (/) => {
+                // The / route outputs an HTML client so that the user can try the websockets.
+                Response::html("<script type=\"text/javascript\">
+                    var socket = new WebSocket(\"ws://localhost:8000/ws\", \"echo\");
+                    function send(data) {{
+                        socket.send(data);
+                    }}
+                    socket.onmessage = function(event) {{
+                        document.getElementById('result').innerHTML += event.data + '<br />';
+                    }}
+                    </script>
+                    <p>This example sends back everything you send to the server.</p>
+                    <p><form onsubmit=\"send(document.getElementById('msg').value); return false;\">
+                    <input type=\"text\" id=\"msg\" />
+                    <button type=\"submit\">Send</button>
+                    </form></p>
+                    <p>Received: </p>
+                    <p id=\"result\"></p>")
+            },
+
+            (GET) (/ws) => {
+                // This is the websockets route.
+
+                // In order to start using websockets we call `websocket::start`.
+                // The function returns an error if the client didn't request websockets, in which
+                // case we return an error 400 to the client thanks to the `try_or_400!` macro.
+                //
+                // The function returns a response to send back as part of the `start_server`
+                // function, and a `websocket` variable of type `Receiver<Websocket>`.
+                // Once the response has been sent back to the client, the `Receiver` will be
+                // filled by rouille with a `Websocket` object representing the websocket.
+                let (response, websocket) = try_or_400!(websocket::start(&request, Some("echo")));
+
+                // Because of the nature of I/O in Rust, we need to spawn a separate thread for
+                // each websocket.
+                thread::spawn(move || {
+                    // This line will block until the `response` above has been returned.
+                    let ws = websocket.recv().unwrap();
+                    // We use a separate function for better readability.
+                    websocket_handling_thread(ws);
+                });
+
+                response
+            },
+
+            // Default 404 route as with all examples.
+            _ => rouille::Response::empty_404()
+        )
+    });
+}
+
+// Function run in a separate thread.
+fn websocket_handling_thread(mut websocket: websocket::Websocket) {
+    loop {
+        // We wait for a new message to come from the websocket.
+        let message = match websocket.next() {
+            Some(m) => m,
+            None => break,
+        };
+
+        match message {
+            websocket::Message::Text(txt) => {
+                // If the message is text, send it back with `send_text`.
+                println!("received {:?} from a websocket", txt);
+                websocket.send_text(&txt).unwrap();
+            },
+            websocket::Message::Binary(_) => {
+                println!("received binary from a websocket");
+            },
+        }
+    }
+}

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -132,7 +132,8 @@ pub fn match_assets<P: ?Sized>(request: &Request, path: &P) -> Response
                 ("Cache-Control".to_owned(), "public, max-age=3600".to_owned()),
                 ("ETag".to_owned(), etag.to_string())
             ],
-            data: ResponseBody::empty()
+            data: ResponseBody::empty(),
+            upgrade: None,
         };
     }
 
@@ -144,6 +145,7 @@ pub fn match_assets<P: ?Sized>(request: &Request, path: &P) -> Response
             ("ETag".to_owned(), etag.to_string())
         ],
         data: ResponseBody::from_file(file),
+        upgrade: None,
     }
 }
 

--- a/src/cgi.rs
+++ b/src/cgi.rs
@@ -133,6 +133,7 @@ impl CgiRun for Command {
                 status_code: status,
                 headers: headers,
                 data: ResponseBody::from_reader(stdout),
+                upgrade: None,
             }
         };
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -172,5 +172,6 @@ pub fn proxy<A>(request: &Request, config: ProxyConfig<A>) -> Result<Response, P
         status_code: status,
         headers: headers,
         data: ResponseBody::from_reader(socket),
+        upgrade: None,
     })
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -12,6 +12,7 @@ use std::io::Cursor;
 use std::io::Read;
 use std::fs::File;
 use rustc_serialize;
+use Upgrade;
 
 /// Contains a prototype of a response.
 ///
@@ -30,6 +31,13 @@ pub struct Response {
 
     /// An opaque type that contains the body of the response.
     pub data: ResponseBody,
+
+    /// If set, rouille will give ownership of the client socket to the `Upgrade` object.
+    ///
+    /// In all circumstances, the value of the `Connection` header is managed by the framework and
+    /// cannot be customized. If this value is set, the response will automatically contain
+    /// `Connection: Upgrade`.
+    pub upgrade: Option<Box<Upgrade + Send>>,
 }
 
 impl Response {
@@ -77,6 +85,7 @@ impl Response {
             status_code: 303,
             headers: vec![("Location".to_owned(), target.to_owned())],
             data: ResponseBody::empty(),
+            upgrade: None,
         }
     }
 
@@ -94,6 +103,7 @@ impl Response {
             status_code: 200,
             headers: vec![("Content-Type".to_owned(), "text/html; charset=utf8".to_owned())],
             data: ResponseBody::from_data(content),
+            upgrade: None,
         }
     }
 
@@ -111,6 +121,7 @@ impl Response {
             status_code: 200,
             headers: vec![("Content-Type".to_owned(), "image/svg+xml; charset=utf8".to_owned())],
             data: ResponseBody::from_data(content),
+            upgrade: None,
         }
     }
 
@@ -128,6 +139,7 @@ impl Response {
             status_code: 200,
             headers: vec![("Content-Type".to_owned(), "text/plain; charset=utf8".to_owned())],
             data: ResponseBody::from_string(text),
+            upgrade: None,
         }
     }
 
@@ -159,6 +171,7 @@ impl Response {
             status_code: 200,
             headers: vec![("Content-Type".to_owned(), "application/json".to_owned())],
             data: ResponseBody::from_data(data),
+            upgrade: None,
         }
     }
 
@@ -178,6 +191,7 @@ impl Response {
             status_code: 401,
             headers: vec![("WWW-Authenticate".to_owned(), format!("Basic realm=\"{}\"", realm))],
             data: ResponseBody::empty(),
+            upgrade: None,
         }
     }
 
@@ -194,7 +208,8 @@ impl Response {
         Response {
             status_code: 400,
             headers: vec![],
-            data: ResponseBody::empty()
+            data: ResponseBody::empty(),
+            upgrade: None,
         }
     }
 
@@ -211,7 +226,8 @@ impl Response {
         Response {
             status_code: 404,
             headers: vec![],
-            data: ResponseBody::empty()
+            data: ResponseBody::empty(),
+            upgrade: None,
         }
     }
 

--- a/src/websocket/low_level.rs
+++ b/src/websocket/low_level.rs
@@ -1,0 +1,358 @@
+// Copyright (c) 2016 The Rouille developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+//! Low-level parsing of websocket frames.
+//!
+//! Usage:
+//!
+//! - Create a `StateMachine` with `StateMachine::new`.
+//! - Whenever data is received on the socket, call `StateMachine::feed`.
+//! - The returned iterator produces zero, one or multiple `Element` objects containing what was
+//!   received.
+//! - For `Element::Data`, the `Data` object is an iterator over the decoded bytes.
+//! - If `Element::Error` is produced, immediately end the connection.
+//!
+//! Glossary:
+//!
+//! - A websocket stream is made of multiple *messages*.
+//! - Each message is made of one or more *frames*. See https://tools.ietf.org/html/rfc6455#section-5.4.
+//! - Each frame can be received progressively, where each packet is an `Element` object (below).
+
+/// A websocket element decoded from the data given to `StateMachine::feed`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Element<'a> {
+    /// A new frame has started.
+    FrameStart {
+        /// If true, this is the last frame of the message.
+        fin: bool,
+        /// Length of the frame in bytes.
+        length: u64,
+        /// Opcode. See https://tools.ietf.org/html/rfc6455#section-5.2.
+        opcode: u8,
+    },
+
+    /// Data was received as part of the current frame.
+    Data {
+        /// The decoded data. An iterator that produces `u8`s.
+        data: Data<'a>,
+        /// If true, this is the last packet in the frame.
+        last_in_frame: bool,
+    },
+
+    /// An error in the stream. The connection must be dropped ASAP.
+    Error {
+        /// A description of the error. Can or cannot be be returned to the client.
+        desc: &'static str
+    },
+}
+
+/// Decoded data. Implements `Iterator<Item = u8>`.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Data<'a> {
+    // Source data. Undecoded.
+    data: &'a [u8],
+    // Copy of the mask of the current frame.
+    mask: u32,
+    // Same as `StateMachineInner::InData::offset`. Updated at each iteration.
+    offset: u8,
+}
+
+/// A websocket state machine. Contains partial data.
+pub struct StateMachine {
+    // Actual state.
+    inner: StateMachineInner,
+    // Contains the start of the header. Must be empty if `inner` is equal to `InData`.
+    buffer: Vec<u8>,        // TODO: use SmallVec?
+}
+
+enum StateMachineInner {
+    // If `StateMachine::inner` is `InHeader`, then `buffer` contains the start of the header.
+    InHeader,
+    // If `StateMachine::inner` is `InData`, then `buffer` must be empty.
+    InData {
+        // Mask to decode the message.
+        mask: u32,
+        // Value between 0 and 3 that indicates the number of bytes between the start of the data
+        // and the next expected byte.
+        offset: u8,
+        // Number of bytes remaining in the frame.
+        remaining_len: u64,
+    }
+}
+
+impl StateMachine {
+    /// Initializes a new state machine for a new stream. Expects to see a new frame as the first
+    /// packet.
+    pub fn new() -> StateMachine {
+        StateMachine {
+            inner: StateMachineInner::InHeader,
+            buffer: Vec::with_capacity(14),
+        }
+    }
+
+    /// Feeds data to the state machine. Returns an iterator to the list of elements that were
+    /// received.
+    #[inline]
+    pub fn feed<'a>(&'a mut self, data: &'a [u8]) -> ElementsIter<'a> {
+        ElementsIter {
+            state: self,
+            data: data,
+        }
+    }
+}
+
+/// Iterator to the list of elements that were received.
+pub struct ElementsIter<'a> {
+    state: &'a mut StateMachine,
+    data: &'a [u8],
+}
+
+impl<'a> Iterator for ElementsIter<'a> {
+    type Item = Element<'a>;
+
+    fn next(&mut self) -> Option<Element<'a>> {
+        if self.data.is_empty() {
+            return None;
+        }
+
+        match self.state.inner {
+            // First situation, we are in the header.
+            StateMachineInner::InHeader => {
+                // We need at least 6 bytes for a succesful header. Otherwise we just return.
+                let total_buffered = self.state.buffer.len() + self.data.len();
+                if total_buffered < 6 {
+                    self.state.buffer.extend_from_slice(self.data);
+                    self.data = &[];
+                    return None;
+                }
+
+                // Retreive the first two bytes of the header.
+                let (first_byte, second_byte) = {
+                    let mut mask_iter = self.state.buffer.iter().chain(self.data.iter());
+                    let first_byte = *mask_iter.next().unwrap();
+                    let second_byte = *mask_iter.next().unwrap();
+                    (first_byte, second_byte)
+                };
+
+                // Reserved bits must be zero, otherwise error.
+                if (first_byte & 0x70) != 0 {
+                    return Some(Element::Error {
+                        desc: "Reserved bits must be zero"
+                    });
+                }
+
+                // Client-to-server messages **must** be encoded.
+                if (second_byte & 0x80) == 0 {
+                    return Some(Element::Error {
+                        desc: "Client-to-server messages must be masked"
+                    });
+                }
+    
+                // Find the length of the frame and the mask.
+                let (length, mask) = match second_byte & 0x7f {
+                    126 => {
+                        if total_buffered < 8 {
+                            self.state.buffer.extend_from_slice(self.data);
+                            self.data = &[];
+                            return None;
+                        }
+
+                        let mut mask_iter = self.state.buffer.iter().chain(self.data.iter()).skip(2);
+
+                        let length = {
+                            let a = *mask_iter.next().unwrap() as u64;
+                            let b = *mask_iter.next().unwrap() as u64;
+                            (a << 8) | (b << 0)
+                        };
+
+                        let mask = {
+                            let a = *mask_iter.next().unwrap() as u32;
+                            let b = *mask_iter.next().unwrap() as u32;
+                            let c = *mask_iter.next().unwrap() as u32;
+                            let d = *mask_iter.next().unwrap() as u32;
+                            (a << 24) | (b << 16) | (c << 8) | (d << 0) 
+                        };
+
+                        (length, mask)
+                    },
+                    127 => {
+                        if total_buffered < 8 {
+                            self.state.buffer.extend_from_slice(self.data);
+                            self.data = &[];
+                            return None;
+                        }
+
+                        let mut mask_iter = self.state.buffer.iter().chain(self.data.iter()).skip(2);
+
+                        let length = {
+                            let a = *mask_iter.next().unwrap() as u64;
+                            let b = *mask_iter.next().unwrap() as u64;
+                            let c = *mask_iter.next().unwrap() as u64;
+                            let d = *mask_iter.next().unwrap() as u64;
+                            let e = *mask_iter.next().unwrap() as u64;
+                            let f = *mask_iter.next().unwrap() as u64;
+                            let g = *mask_iter.next().unwrap() as u64;
+                            let h = *mask_iter.next().unwrap() as u64;
+
+                            // The most significant bit must be zero according to the specs.
+                            if (a & 0x80) != 0 {
+                                return Some(Element::Error {
+                                    desc: "Most-significant bit of the length must be zero"
+                                });
+                            }
+
+                            (a << 56) | (b << 48) | (c << 40) | (d << 32) |
+                                (e << 24) | (f << 16) | (g << 8) | (h << 0)
+                        };
+
+                        let mask = {
+                            let a = *mask_iter.next().unwrap() as u32;
+                            let b = *mask_iter.next().unwrap() as u32;
+                            let c = *mask_iter.next().unwrap() as u32;
+                            let d = *mask_iter.next().unwrap() as u32;
+                            (a << 24) | (b << 16) | (c << 8) | (d << 0) 
+                        };
+
+                        (length, mask)
+                    },
+                    n => {             
+                        let mut mask_iter = self.state.buffer.iter().chain(self.data.iter()).skip(2);
+           
+                        let mask = {
+                            let a = *mask_iter.next().unwrap() as u32;
+                            let b = *mask_iter.next().unwrap() as u32;
+                            let c = *mask_iter.next().unwrap() as u32;
+                            let d = *mask_iter.next().unwrap() as u32;
+                            (a << 24) | (b << 16) | (c << 8) | (d << 0) 
+                        };
+
+                        (n as u64, mask)
+                    },
+                };
+
+                // Builds a slice containing the start of the data.
+                let data_start = { 
+                    let data_start_off = match second_byte & 0x7f {
+                        126 => 8,
+                        127 => 14,
+                        _ => 6
+                    };
+
+                    assert!(self.state.buffer.len() < data_start_off);
+                    &self.data[(data_start_off - self.state.buffer.len()) ..]
+                };
+
+                // Update ourselves for the next loop and return a FrameStart message.
+                self.data = data_start;
+                self.state.buffer.clear();
+                self.state.inner = StateMachineInner::InData { mask: mask, remaining_len: length,
+                                                               offset: 0 };
+                Some(Element::FrameStart {
+                    fin: (first_byte & 0x80) != 0,
+                    length: length,
+                    opcode: first_byte & 0xf,
+                })
+            },
+
+            // Second situation, we are in the message and we don't have enough data to finish the
+            // current frame.
+            StateMachineInner::InData { mask, ref mut remaining_len, ref mut offset }
+                if *remaining_len > self.data.len() as u64 =>
+            {
+                let data = Data {
+                    data: self.data,
+                    mask: mask,
+                    offset: *offset,
+                };
+
+                *offset += (self.data.len() % 4) as u8;
+                *offset %= 4;
+                *remaining_len -= self.data.len() as u64;
+
+                self.data = &[];
+
+                Some(Element::Data { data: data, last_in_frame: false })
+            },
+
+            // Third situation, we have enough data to finish the frame.
+            StateMachineInner::InData { mask, remaining_len, offset } => {
+                debug_assert!(self.data.len() as u64 >= remaining_len);
+
+                let data = Data {
+                    data: &self.data[0 .. remaining_len as usize],
+                    mask: mask,
+                    offset: offset,
+                };
+
+                self.data = &self.data[remaining_len as usize ..];
+                self.state.inner = StateMachineInner::InHeader;
+                debug_assert!(self.state.buffer.is_empty());
+
+                Some(Element::Data { data: data, last_in_frame: true })
+            },
+        }
+    }
+}
+
+impl<'a> Iterator for Data<'a> {
+    type Item = u8;
+
+    #[inline]
+    fn next(&mut self) -> Option<u8> {
+        if self.data.is_empty() {
+            return None;
+        }
+
+        let byte = self.data[0];
+        let mask = ((self.mask >> (3 - self.offset) * 8) & 0xff) as u8;
+        let decoded = byte ^ mask;
+
+        self.data = &self.data[1..];
+        self.offset = (self.offset + 1) % 4;
+
+        Some(decoded)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let l = self.data.len();
+        (l, Some(l))
+    }
+}
+
+impl<'a> ExactSizeIterator for Data<'a> {
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Element;
+    use super::StateMachine;
+
+    #[test]
+    fn basic() {
+        let mut machine = StateMachine::new();
+
+        let data = &[0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58];
+        let mut iter = machine.feed(data);
+
+        assert_eq!(iter.next().unwrap(), Element::FrameStart {
+            fin: true,
+            length: 5,
+            opcode: 1
+        });
+
+        match iter.next().unwrap() {
+            Element::Data { data, last_in_frame } => {
+                assert!(last_in_frame);
+                assert_eq!(data.collect::<Vec<_>>(), b"Hello");
+            }
+            _ => panic!()
+        }
+    }
+}

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -1,0 +1,221 @@
+// Copyright (c) 2016 The Rouille developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+//! Support for websockets.
+//!
+//! Using websockets is done with the following steps:
+//!
+//! - The websocket client (usually the browser through some Javascript) must send a request to the
+//!   server to initiate the process. Examples for how to do this in Javascript are out of scope
+//!   of this documentation but should be easy to find on the web.
+//! - The server written with rouille must answer that request with the `start()` function defined
+//!   in this module. This function returns an error if the request is not a websocket
+//!   initialization request.
+//! - The `start()` function also returns a `Receiver<Websocket>` object. Once that `Receiver`
+//!   contains a value, the connection has been initiated.
+//! - You can then use the `Websocket` object to communicate with the client through the `Read`
+//!   and `Write` traits.
+//!
+//! # Subprotocols
+//!
+//! The websocket connection will produce either text or binary messages. But these messages do not
+//! have a meaning per se, and must also be interpreted in some way. The way messages are
+//! interpreted during a websocket connection is called a *subprotocol*.
+//!
+//! When you call `start()` you have to indicate which subprotocol the connection is going to use.
+//! This subprotocol must match one of the subprotocols that were passed by the client during its
+//! request, otherwise `start()` will return an error. It is also possible to pass `None`, in which
+//! case the subprotocol is unknown to both the client and the server.
+//!
+//! There are usually three ways to handle subprotocols on the server-side:
+//!
+//! - You don't really care about subprotocols because you use websockets for your own needs. You
+//!   can just pass `None` to `start()`. The connection will thus never fail unless the client
+//!   decides to.
+//! - Your route only handles one subprotocol. Just pass this subprotocol to `start()` and you will
+//!   get an error (which you can handle for example with `try_or_400!`) if it's not supported by
+//!   the client.
+//! - Your route supports multiple subprotocols. This is the most complex situation as you will
+//!   have to enumerate the protocols with `requested_protocols()` and choose one.
+//!
+//! # Example
+//! 
+//! ```
+//! # #[macro_use] extern crate rouille;
+//! use std::sync::Mutex;
+//! use std::sync::mpsc::Receiver;
+//!
+//! use rouille::Request;
+//! use rouille::Response;
+//! use rouille::websocket;
+//! # fn main() {}
+//!
+//! fn handle_request(request: &Request, websockets: &Mutex<Vec<Receiver<websocket::Websocket>>>)
+//!                   -> Response
+//! {
+//!     let (response, websocket) = try_or_400!(websocket::start(request, Some("my-subprotocol")));
+//!     websockets.lock().unwrap().push(websocket);
+//!     response
+//! }
+//! ```
+
+pub use self::websocket::Message;
+pub use self::websocket::SendError;
+pub use self::websocket::Websocket;
+
+use std::ascii::AsciiExt;
+use std::sync::mpsc;
+use std::vec::IntoIter as VecIntoIter;
+use sha1::Sha1;
+use rustc_serialize::base64::Config;
+use rustc_serialize::base64::Standard;
+use rustc_serialize::base64::Newline;
+use rustc_serialize::base64::ToBase64;
+use tiny_http::HTTPVersion;
+
+use Request;
+use Response;
+
+mod low_level;
+mod websocket;
+
+/// Error that can happen when attempting to start websocket.
+#[derive(Debug)]
+pub enum WebsocketError {
+    /// The request does not match a websocket request.
+    ///
+    /// The conditions are:
+    /// - The method must be `GET`.
+    /// - The HTTP version must be at least 1.1.
+    /// - The request must include `Host`.
+    /// - The `Connection` header must include `websocket`.
+    /// - The `Sec-WebSocket-Version` header must be `13`.
+    /// - Must have a `Sec-WebSocket-Key` header.
+    InvalidWebsocketRequest,
+
+    /// The subprotocol passed to the function was not requested by the client.
+    WrongSubprotocol,
+}
+
+/// Builds a `Response` that initiates the websocket protocol.
+pub fn start(request: &Request, subprotocol: Option<&str>)
+             -> Result<(Response, mpsc::Receiver<Websocket>), WebsocketError>
+{
+    if request.method() != "GET" {
+        return Err(WebsocketError::InvalidWebsocketRequest);
+    }
+
+    // TODO:
+    /*if request.http_version() < &HTTPVersion(1, 1) {
+        return Err(WebsocketError::InvalidWebsocketRequest);
+    }*/
+
+    match request.header("Connection") {
+        Some(ref h) if h.to_ascii_lowercase().contains("upgrade") => (),
+        _ => return Err(WebsocketError::InvalidWebsocketRequest),
+    }
+
+    match request.header("Upgrade") {
+        Some(ref h) if h.to_ascii_lowercase().contains("websocket") => (),
+        _ => return Err(WebsocketError::InvalidWebsocketRequest),
+    }
+
+    // TODO: there are some version shanigans to handle
+    // see https://tools.ietf.org/html/rfc6455#section-4.4
+    match request.header("Sec-WebSocket-Version") {
+        Some(ref h) if h == "13" => (),
+        _ => return Err(WebsocketError::InvalidWebsocketRequest),
+    }
+
+    if let Some(sp) = subprotocol {
+        if !requested_protocols(request).any(|p| p == sp) {
+            return Err(WebsocketError::WrongSubprotocol);
+        }
+    }
+
+    let key = {
+        let in_key = match request.header("Sec-WebSocket-Key") {
+            Some(h) => h,
+            None => return Err(WebsocketError::InvalidWebsocketRequest),
+        };
+
+        convert_key(&in_key)
+    };
+
+    let (tx, rx) = mpsc::channel();
+
+    let mut response = Response::text("");
+    response.status_code = 101;
+    response.headers.push(("Upgrade".into(), "websocket".into()));
+    if let Some(sp) = subprotocol {
+        response.headers.push(("Sec-Websocket-Protocol".into(), sp.to_owned()));
+    }
+    response.headers.push(("Sec-Websocket-Accept".into(), key));
+    response.upgrade = Some(Box::new(tx) as Box<_>);
+    Ok((response, rx))
+}
+
+/// Returns a list of the websocket protocols requested by the client.
+///
+/// # Example
+///
+/// ```
+/// use rouille::websocket;
+/// 
+/// # let request: rouille::Request = return;
+/// for protocol in websocket::requested_protocols(&request) {
+///     // ...
+/// }
+/// ```
+// TODO: return references to the request
+pub fn requested_protocols(request: &Request) -> RequestedProtocolsIter {
+    match request.header("Sec-WebSocket-Protocol") {
+        None => RequestedProtocolsIter { iter: Vec::new().into_iter() },
+        Some(h) => {
+            let iter = h.split(',')
+                        .map(|s| s.trim())
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_owned())
+                        .collect::<Vec<_>>().into_iter();
+            RequestedProtocolsIter { iter: iter }
+        }
+    }
+}
+
+/// Iterator to the list of protocols requested by the user.
+pub struct RequestedProtocolsIter {
+    iter: VecIntoIter<String>,
+}
+
+impl Iterator for RequestedProtocolsIter {
+    type Item = String;
+
+    #[inline]
+    fn next(&mut self) -> Option<String> {
+        self.iter.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl ExactSizeIterator for RequestedProtocolsIter {
+}
+
+/// Turns a `Sec-WebSocket-Key` into a `Sec-WebSocket-Accept`.
+fn convert_key(input: &str) -> String {
+    let mut sha1 = Sha1::new();
+    sha1.update(input.as_bytes());
+    sha1.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+
+    sha1.digest().bytes().to_base64(Config { char_set: Standard, pad: true,
+                                             line_length: None, newline: Newline::LF })
+}

--- a/src/websocket/websocket.rs
+++ b/src/websocket/websocket.rs
@@ -1,0 +1,342 @@
+// Copyright (c) 2016 The Rouille developers
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+// at your option. All files in the project carrying such
+// notice may not be copied, modified, or distributed except
+// according to those terms.
+
+use std::io;
+use std::io::Write;
+use std::mem;
+use std::sync::mpsc::Sender;
+use ReadWrite;
+use Upgrade;
+
+use websocket::low_level;
+
+/// A successful websocket. An open channel of communication. Implements `Read` and `Write`.
+pub struct Websocket {
+    // The socket. `None` if closed.
+    socket: Option<Box<ReadWrite + Send>>,
+    // The websocket state machine.
+    state_machine: low_level::StateMachine,
+    // True if the fragmented message currently being processed is binary. False if string. Pings
+    // are excluded.
+    current_message_binary: bool,
+    // Buffer for the fragmented message currently being processed. Pings are excluded.
+    current_message_payload: Vec<u8>,
+    // Opcode of the fragment currently being processed.
+    current_frame_opcode: u8,
+    // Fin flag of the fragment currently being processed.
+    current_frame_fin: bool,
+    // Data of the fragment currently being processed.
+    current_frame_payload: Vec<u8>,
+    // Queue of the messages that are going to be returned by `next()`.
+    messages_in_queue: Vec<Message>,
+}
+
+/// A message produced by a websocket connection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Message {
+    /// Text data. If the client is in Javascript, this happens when the client called `send()`
+    /// with a string. 
+    Text(String),
+
+    /// Binary data. If the client is in Javascript, this happens when the client called `send()`
+    /// with a blob or an arraybuffer.
+    Binary(Vec<u8>),
+}
+
+/// Error that can happen when sending a message to the client.
+#[derive(Debug)]
+pub enum SendError {
+    /// Failed to transfer the message on the socket.
+    IoError(io::Error),
+
+    /// The websocket connection is closed.
+    Closed,
+}
+
+impl From<io::Error> for SendError {
+    #[inline]
+    fn from(err: io::Error) -> SendError {
+        SendError::IoError(err)
+    }
+}
+
+impl Websocket {
+    /// Sends text data over the websocket.
+    ///
+    /// Returns an error if the message didn't send correctly or if the connection is closed.
+    ///
+    /// If the client is in javascript, the message will contain a string.
+    #[inline]
+    pub fn send_text(&mut self, data: &str) -> Result<(), SendError> {
+        let socket = match self.socket {
+            Some(ref mut s) => s,
+            None => return Err(SendError::Closed),
+        };
+
+        try!(send(data.as_bytes(), Write::by_ref(socket), 0x1));
+        Ok(())
+    }
+
+    /// Sends binary data over the websocket.
+    ///
+    /// Returns an error if the message didn't send correctly or if the connection is closed.
+    ///
+    /// If the client is in javascript, the message will contain a blob or an arraybuffer.
+    #[inline]
+    pub fn send_binary(&mut self, data: &[u8]) -> Result<(), SendError> {
+        let socket = match self.socket {
+            Some(ref mut s) => s,
+            None => return Err(SendError::Closed),
+        };
+
+        try!(send(data, Write::by_ref(socket), 0x2));
+        Ok(())
+    }
+
+    /// Returns `true` if the websocket has been closed by either the client (voluntarily or not)
+    /// or by the server (if the websocket protocol was violated).
+    #[inline]
+    pub fn is_closed(&self) -> bool {
+        self.socket.is_none()
+    }
+
+    // TODO: give access to close reason
+}
+
+impl Upgrade for Sender<Websocket> {
+    fn build(&mut self, socket: Box<ReadWrite + Send>) {
+        let websocket = Websocket {
+            socket: Some(socket),
+            state_machine: low_level::StateMachine::new(),
+            current_message_binary: false,
+            current_message_payload: Vec::new(),
+            current_frame_opcode: 0,
+            current_frame_fin: false,
+            current_frame_payload: Vec::new(),
+            messages_in_queue: Vec::new(),
+        };
+
+        let _ = self.send(websocket);
+    }
+}
+
+impl Iterator for Websocket {
+    type Item = Message;
+
+    fn next(&mut self) -> Option<Message> {
+        loop {
+            // If the socket is `None`, the connection has been closed.
+            if self.socket.is_none() {
+                return None;
+            }
+
+            // There may be some messages waiting to be processed.
+            if !self.messages_in_queue.is_empty() {
+                return Some(self.messages_in_queue.remove(0));
+            }
+
+            // Read `n` bytes in `buf`.
+            let mut buf = [0; 256];
+            let n = match self.socket.as_mut().unwrap().read(&mut buf) {
+                Ok(n) => n,
+                Err(ref err) if err.kind() == io::ErrorKind::Interrupted => 0,
+                Err(_) => {
+                    self.socket = None;
+                    return None;
+                },
+            };
+
+            // Fill `messages_in_queue` by analyzing the packets.
+            for element in self.state_machine.feed(&buf[0 .. n]) {
+                match element {
+                    low_level::Element::FrameStart { fin, opcode, .. } => {
+                        debug_assert!(self.current_frame_payload.is_empty());
+                        self.current_frame_fin = fin;
+                        self.current_frame_opcode = opcode;
+                    },
+
+                    low_level::Element::Data { data, last_in_frame } => {
+                        // Under normal circumstances we just handle data by pushing it to
+                        // `current_frame_payload`.
+                        self.current_frame_payload.extend(data);
+
+                        // But if the frame is finished we additionnally need to dispatch it.
+                        if last_in_frame {
+                            match self.current_frame_opcode {
+                                // Frame is a continuation of the current message.
+                                0x0 => {
+                                    self.current_message_payload.append(&mut self.current_frame_payload);
+
+                                    // If the message is finished, dispatch it.
+                                    if self.current_frame_fin {
+                                        let binary = mem::replace(&mut self.current_message_payload, Vec::new());
+
+                                        if self.current_message_binary {
+                                            self.messages_in_queue.push(Message::Binary(binary));
+                                        } else {
+                                            let string = match String::from_utf8(binary) {
+                                                Ok(s) => s,
+                                                Err(_) => {
+                                                    // Closing connection because text wasn't UTF-8
+                                                    send(b"1007 Invalid UTF-8 encoding",
+                                                         Write::by_ref(self.socket.as_mut().unwrap()), 0x8);
+                                                    self.socket = None;
+                                                    return None;
+                                                },
+                                            };
+
+                                            self.messages_in_queue.push(Message::Text(string));
+                                        }
+                                    }
+                                },
+
+                                // Frame is an individual text frame.
+                                0x1 => {
+                                    // If we're in the middle of a message, this frame is invalid
+                                    // and we need to close.
+                                    if !self.current_message_payload.is_empty() {
+                                        send(b"1002 Expected continuation frame",
+                                             Write::by_ref(self.socket.as_mut().unwrap()), 0x8);
+                                        self.socket = None;
+                                        return None;
+                                    }
+
+                                    if self.current_frame_fin {
+                                        // There's only one frame in this message.
+                                        let binary = mem::replace(&mut self.current_frame_payload,
+                                                                  Vec::new());
+                                        let string = match String::from_utf8(binary) {
+                                            Ok(s) => s,
+                                            Err(err) => {
+                                                // Closing connection because text wasn't UTF-8
+                                                send(b"1007 Invalid UTF-8 encoding",
+                                                     Write::by_ref(self.socket.as_mut().unwrap()),
+                                                     0x8);
+                                                self.socket = None;
+                                                return None;
+                                            },
+                                        };
+
+                                        self.messages_in_queue.push(Message::Text(string));
+
+                                    } else {
+                                        // Start of a fragmented message.
+                                        self.current_message_binary = false;
+                                        self.current_message_payload.append(&mut self.current_frame_payload);
+                                    }
+                                },
+
+                                // Frame is an individual binary frame.
+                                0x2 => {
+                                    // If we're in the middle of a message, this frame is invalid
+                                    // and we need to close.
+                                    if !self.current_message_payload.is_empty() {
+                                        send(b"1002 Expected continuation frame",
+                                             Write::by_ref(self.socket.as_mut().unwrap()), 0x8);
+                                        self.socket = None;
+                                        return None;
+                                    }
+
+                                    if self.current_frame_fin {
+                                        let binary = mem::replace(&mut self.current_frame_payload,
+                                                                  Vec::new());
+                                        self.messages_in_queue.push(Message::Binary(binary));
+                                    } else {
+                                        // Start of a fragmented message.
+                                        self.current_message_binary = true;
+                                        self.current_message_payload.append(&mut self.current_frame_payload);
+                                    }
+                                },
+
+                                // Close request.
+                                0x8 => {
+                                    // We need to send a confirmation.
+                                    send(&self.current_frame_payload,
+                                         Write::by_ref(self.socket.as_mut().unwrap()), 0x8);
+                                    // Since the packets are always received in order, and since
+                                    // the server is considered dead as soon as it sends the
+                                    // confirmation, we have no risk of losing packets.
+                                    self.socket = None;
+                                    return None;
+                                },
+
+                                // Ping.
+                                0x9 => {
+                                    // Send the pong.
+                                    send(&self.current_frame_payload,
+                                         Write::by_ref(self.socket.as_mut().unwrap()), 0xA);
+                                },
+
+                                // Pong. We ignore this as there's nothing to do.
+                                0xA => {},
+
+                                // Unknown opcode means error and close.
+                                _ => {
+                                    send(b"Unknown opcode",
+                                         Write::by_ref(self.socket.as_mut().unwrap()), 0x8);
+                                    self.socket = None;
+                                    return None;
+                                },
+                            }
+
+                            self.current_frame_payload.clear();
+                        }
+                    },
+
+                    low_level::Element::Error { desc } => {
+                        // The low level layer signaled an error. Sending it to client and closing.
+                        send(desc.as_bytes(), Write::by_ref(self.socket.as_mut().unwrap()), 0x8);
+                        self.socket = None;
+                        return None;
+                    },
+                }
+            }
+        }
+    }
+}
+
+// Sends a mesage to a websocket.
+// TODO: message fragmentation?
+fn send<W: Write>(data: &[u8], mut dest: W, opcode: u8) -> io::Result<()> {
+    // Write the opcode
+    assert!(opcode <= 0xf);
+    let first_byte = 0x80 | opcode;
+    try!(dest.write_all(&[first_byte]));
+
+    // Write the length
+    if data.len() >= 65536 {
+        try!(dest.write_all(&[127u8]));
+        let len = data.len() as u64;
+        assert!(len < 0x8000_0000_0000_0000);
+        let len1 = (len >> 56) as u8;
+        let len2 = (len >> 48) as u8;
+        let len3 = (len >> 40) as u8;
+        let len4 = (len >> 32) as u8;
+        let len5 = (len >> 24) as u8;
+        let len6 = (len >> 16) as u8;
+        let len7 = (len >> 8) as u8;
+        let len8 = (len >> 0) as u8;
+        try!(dest.write_all(&[len1, len2, len3, len4, len5, len6, len7, len8]));
+
+    } else if data.len() >= 126 {
+        try!(dest.write_all(&[126u8]));
+        let len = data.len() as u16;
+        let len1 = (len >> 8) as u8;
+        let len2 = len as u8;
+        try!(dest.write_all(&[len1, len2]));
+
+    } else {
+        try!(dest.write_all(&[data.len() as u8]));
+    }
+
+    // Write the data
+    try!(dest.write_all(data));
+    try!(dest.flush());
+    Ok(())
+}


### PR DESCRIPTION
- Adds the `Response::upgrade` field. Adds the `Upgrade` trait.
- Adds the `websocket` module.

Example usage: https://github.com/tomaka/rouille/blob/4c9351e8e8272e3a8e4294f12746f26edb730f7c/examples/websocket.rs

Fix #67 

~~Needs to switch back to tiny-http from crates.io once https://github.com/frewsxcv/tiny-http/pull/124 is merged.~~
Done.