### PR TITLE
Add `is_` prefix to bool methods

### DIFF
--- a/examples/database.rs
+++ b/examples/database.rs
@@ -86,7 +86,7 @@ fn main() {
 
         // If the response is a success, we commit the transaction before returning. It's only at
         // this point that data are actually written in the database.
-        if response.success() {
+        if response.is_success() {
             db.commit().unwrap();
         }
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -34,7 +34,7 @@ use ResponseBody;
 /// ```no_run
 /// rouille::start_server("localhost:8000", move |request| {
 ///     let response = rouille::match_assets(&request, "public");
-///     if response.success() {
+///     if response.is_success() {
 ///         return response;
 ///     }
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,7 +428,7 @@ impl Request {
     /// use rouille::{Request, Response};
     ///
     /// fn handle(request: &Request) -> Response {
-    ///     if !request.secure() {
+    ///     if !request.is_secure() {
     ///         return Response::redirect(&format!("https://example.com"));
     ///     }
     ///
@@ -437,7 +437,7 @@ impl Request {
     /// }
     /// ```
     #[inline]
-    pub fn secure(&self) -> bool {
+    pub fn is_secure(&self) -> bool {
         self.https
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -50,25 +50,25 @@ impl Response {
     /// ```
     /// use rouille::Response;
     /// let response = Response::text("hello world");
-    /// assert!(response.success());
+    /// assert!(response.is_success());
     /// ```
     #[inline]
-    pub fn success(&self) -> bool {
+    pub fn is_success(&self) -> bool {
         self.status_code >= 200 && self.status_code < 400
     }
 
-    /// Shortcut for `!response.success()`.
+    /// Shortcut for `!response.is_success()`.
     ///
     /// # Example
     ///
     /// ```
     /// use rouille::Response;
     /// let response = Response::empty_400();
-    /// assert!(response.error());
+    /// assert!(response.is_error());
     /// ```
     #[inline]
-    pub fn error(&self) -> bool {
-        !self.success()
+    pub fn is_error(&self) -> bool {
+        !self.is_success()
     }
 
     /// Builds a `Response` that redirects the user to another URL with a 303 status code.


### PR DESCRIPTION
This change makes it clear that these methods *query* the property, not *set* it.

This also makes the naming more consistent with existing Rust code (see [the standard library][1] for example).

[1]: https://doc.rust-lang.org/std/?search=is_