### PR TITLE
Change `Response::html` and `Response::svg` to take `Into<String>`

### DIFF
--- a/examples/simple_form.rs
+++ b/examples/simple_form.rs
@@ -15,7 +15,7 @@ fn main() {
                 (GET) (/) => {
                     let mut output = Vec::new();
                     form.render_data(&mut output, &mustache::Data::Bool(false));
-                    rouille::Response::html(output)
+                    rouille::Response::html(String::from_utf8(output).unwrap())
                 },
 
                 (POST) (/submit) => {
@@ -32,7 +32,7 @@ fn main() {
 
                     let mut output = Vec::new();
                     form_success.render(&mut output, &template_out).unwrap();
-                    rouille::Response::html(output)
+                    rouille::Response::html(String::from_utf8(output).unwrap())
                 },
 
                 _ => rouille::Response::empty_404()

--- a/src/response.rs
+++ b/src/response.rs
@@ -98,11 +98,11 @@ impl Response {
     /// let response = Response::text("<p>hello <strong>world</strong></p>");
     /// ```
     #[inline]
-    pub fn html<D>(content: D) -> Response where D: Into<Vec<u8>> {
+    pub fn html<D>(content: D) -> Response where D: Into<String> {
         Response {
             status_code: 200,
             headers: vec![("Content-Type".to_owned(), "text/html; charset=utf8".to_owned())],
-            data: ResponseBody::from_data(content),
+            data: ResponseBody::from_string(content),
             upgrade: None,
         }
     }
@@ -116,11 +116,11 @@ impl Response {
     /// let response = Response::svg("<svg xmlns='http://www.w3.org/2000/svg'/>");
     /// ```
     #[inline]
-    pub fn svg<D>(content: D) -> Response where D: Into<Vec<u8>> {
+    pub fn svg<D>(content: D) -> Response where D: Into<String> {
         Response {
             status_code: 200,
             headers: vec![("Content-Type".to_owned(), "image/svg+xml; charset=utf8".to_owned())],
-            data: ResponseBody::from_data(content),
+            data: ResponseBody::from_string(content),
             upgrade: None,
         }
     }


### PR DESCRIPTION
Currently, the `Response::html` constructor sets UTF-8 encoding in the Content-Type header. But because this constructor takes raw bytes (`Into<Vec<u8>>`), a user can pass in data encoded using e.g. Shift JIS instead. Since the Content-Type header overrides any `<meta charset>` tags in the response body (see [spec]), this will silently corrupt the page. A similar argument applies to `Response::svg`.

One hiccup was with the mustache library, which doesn't expose a method to render a `String` directly. I have submitted nickel-org/rust-mustache#43 to fix this.

[spec]: https://html.spec.whatwg.org/multipage/syntax.html#encoding-sniffing-algorithm