### PR TITLE
Make the status code of redirect() explicit

### DIFF
--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -32,7 +32,7 @@ fn main() {
             (GET) (/) => {
                 // If the request's URL is `/`, we jump here.
                 // This block builds a `Response` object that redirects to the `/hello/world`.
-                rouille::Response::redirect("/hello/world")
+                rouille::Response::redirect_302("/hello/world")
             },
 
             (GET) (/hello/world) => {

--- a/examples/login-session.rs
+++ b/examples/login-session.rs
@@ -120,7 +120,7 @@ fn handle_route(request: &Request, session_data: &mut Option<SessionData>) -> Re
                 // including an attempt at XSS. Storing in memory what the user gave us is not
                 // wrong, but we have to take care not to interpret it as HTML data for example.
                 *session_data = Some(SessionData { login: data.login });
-                return Response::redirect("/");
+                return Response::redirect_303("/");
 
             } else {
                 // We return a dummy response to indicate that the login failed. In a real
@@ -177,7 +177,7 @@ fn handle_route(request: &Request, session_data: &mut Option<SessionData>) -> Re
                 // this example is structured is appropriate for a website that is entirely
                 // private. Don't hesitate to structure it in a different way, for example by
                 // having a function that is dedicated only to public routes.
-                Response::redirect("/")
+                Response::redirect_303("/")
             }
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,7 +430,7 @@ impl Request {
     ///
     /// fn handle(request: &Request) -> Response {
     ///     if !request.is_secure() {
-    ///         return Response::redirect(format!("https://example.com"));
+    ///         return Response::redirect_303(format!("https://example.com"));
     ///     }
     ///
     ///     // ...

--- a/src/response.rs
+++ b/src/response.rs
@@ -72,28 +72,136 @@ impl Response {
         !self.is_success()
     }
 
-    /// Builds a `Response` that redirects the user to another URL with a 303 status code.
+    /// Builds a `Response` that redirects the user to another URL with a 301 status code. This
+    /// semantically means a permanent redirect.
+    ///
+    /// > **Note**: If you're uncertain about which status code to use for a redirection, 303 is
+    /// > the safest choice.
     ///
     /// # Example
     ///
     /// ```
     /// use rouille::Response;
-    /// let response = Response::redirect("/foo");
+    /// let response = Response::redirect_301("/foo");
     /// ```
+    #[inline]
+    pub fn redirect_301<S>(target: S) -> Response
+        where S: Into<Cow<'static, str>>
+    {
+        Response {
+            status_code: 301,
+            headers: vec![("Location".into(), target.into())],
+            data: ResponseBody::empty(),
+            upgrade: None,
+        }
+    }
+
+    /// Builds a `Response` that redirects the user to another URL with a 302 status code. This
+    /// semantically means a temporary redirect.
     ///
-    /// Another example with a `String`:
+    /// > **Note**: If you're uncertain about which status code to use for a redirection, 303 is
+    /// > the safest choice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rouille::Response;
+    /// let response = Response::redirect_302("/bar");
+    /// ```
+    #[inline]
+    pub fn redirect_302<S>(target: S) -> Response
+        where S: Into<Cow<'static, str>>
+    {
+        Response {
+            status_code: 302,
+            headers: vec![("Location".into(), target.into())],
+            data: ResponseBody::empty(),
+            upgrade: None,
+        }
+    }
+
+    /// Builds a `Response` that redirects the user to another URL with a 303 status code. This
+    /// means "See Other" and is usually used to indicate where the response of a query is
+    /// located.
+    ///
+    /// For example when a user sends a POST request to URL `/foo` the server can return a 303
+    /// response with a target to `/bar`, in which case the browser will automatically change
+    /// the page to `/bar` (with a GET request to `/bar`).
+    ///
+    /// > **Note**: If you're uncertain about which status code to use for a redirection, 303 is
+    /// > the safest choice.
+    ///
+    /// # Example
     ///
     /// ```
     /// use rouille::Response;
     /// let user_id = 5;
-    /// let response = Response::redirect(format!("/users/{}", user_id));
+    /// let response = Response::redirect_303(format!("/users/{}", user_id));
     /// ```
     #[inline]
-    pub fn redirect<S>(target: S) -> Response
+    pub fn redirect_303<S>(target: S) -> Response
         where S: Into<Cow<'static, str>>
     {
         Response {
             status_code: 303,
+            headers: vec![("Location".into(), target.into())],
+            data: ResponseBody::empty(),
+            upgrade: None,
+        }
+    }
+
+    /// Builds a `Response` that redirects the user to another URL with a 307 status code. This
+    /// semantically means a permanent redirect.
+    ///
+    /// The difference between 307 and 301 is that the client must keep the same method after
+    /// the redirection. For example if the browser sends a POST request to `/foo` and that route
+    /// returns a 307 redirection to `/bar`, then the browser will make a POST request to `/bar`.
+    /// With a 301 redirection it would use a GET request instead.
+    ///
+    /// > **Note**: If you're uncertain about which status code to use for a redirection, 303 is
+    /// > the safest choice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rouille::Response;
+    /// let response = Response::redirect_307("/foo");
+    /// ```
+    #[inline]
+    pub fn redirect_307<S>(target: S) -> Response
+        where S: Into<Cow<'static, str>>
+    {
+        Response {
+            status_code: 307,
+            headers: vec![("Location".into(), target.into())],
+            data: ResponseBody::empty(),
+            upgrade: None,
+        }
+    }
+
+    /// Builds a `Response` that redirects the user to another URL with a 302 status code. This
+    /// semantically means a temporary redirect.
+    ///
+    /// The difference between 308 and 302 is that the client must keep the same method after
+    /// the redirection. For example if the browser sends a POST request to `/foo` and that route
+    /// returns a 308 redirection to `/bar`, then the browser will make a POST request to `/bar`.
+    /// With a 302 redirection it would use a GET request instead.
+    ///
+    /// > **Note**: If you're uncertain about which status code to use for a redirection, 303 is
+    /// > the safest choice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rouille::Response;
+    /// let response = Response::redirect_302("/bar");
+    /// ```
+    #[inline]
+    pub fn redirect_308<S>(target: S) -> Response
+        where S: Into<Cow<'static, str>>
+    {
+        Response {
+            status_code: 308,
             headers: vec![("Location".into(), target.into())],
             data: ResponseBody::empty(),
             upgrade: None,


### PR DESCRIPTION
Adds `redirect_301` to `redirect_308` and removes `redirect`.