### PR TITLE
Add documentation to the response headers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,6 +278,14 @@ pub fn start_server<A, F>(addr: A, handler: F) -> !
                                             .with_data(res_data, res_len);
 
             for (key, value) in rouille_response.headers {
+                if key.eq_ignore_ascii_case("Content-Length") {
+                    continue;
+                }
+
+                if key.eq_ignore_ascii_case("Content-Encoding") {
+                    continue;
+                }
+
                 if let Ok(header) = tiny_http::Header::from_bytes(key.as_bytes(), value.as_bytes()) {
                     response.add_header(header);
                 } else {
@@ -287,7 +295,7 @@ pub fn start_server<A, F>(addr: A, handler: F) -> !
 
             if let Some(ref mut upgrade) = rouille_response.upgrade {
                 let trq = tiny_http_request.lock().unwrap().take().unwrap();
-                let socket = trq.upgrade("websocket", response);
+                let socket = trq.upgrade("websocket", response);        // FIXME:
                 upgrade.build(socket);
 
             } else {

--- a/src/response.rs
+++ b/src/response.rs
@@ -25,9 +25,25 @@ pub struct Response {
 
     /// List of headers to be returned in the response.
     ///
-    /// Note that important headers such as `Connection` or `Content-Length` will be ignored
-    /// from this list.
-    // TODO: document precisely which headers
+    /// The value of the following headers will be ignored from this list, even if present:
+    ///
+    /// - Accept-Ranges
+    /// - Connection
+    /// - Content-Encoding
+    /// - Content-Length
+    /// - Content-Range
+    /// - Trailer
+    /// - Transfer-Encoding
+    /// - Upgrade       FIXME: design this
+    ///
+    /// The reason for this is that these headers are too low-level and are directly handled by
+    /// the underlying HTTP response system.
+    ///
+    /// The value of `Content-Length` is automatically determined by the `ResponseBody` object of
+    /// the `data` member.
+    ///
+    /// If you want to send back `Connection: upgrade`, you should set the value of the `upgrade`
+    /// field to something.
     pub headers: Vec<(Cow<'static, str>, Cow<'static, str>)>,
 
     /// An opaque type that contains the body of the response.

--- a/src/response.rs
+++ b/src/response.rs
@@ -34,7 +34,9 @@ pub struct Response {
     /// - Content-Range
     /// - Trailer
     /// - Transfer-Encoding
-    /// - Upgrade       FIXME: design this
+    ///
+    /// Additionnaly, the `Upgrade` header is ignored as well unless the `upgrade` field of the
+    /// `Response` is set to something.
     ///
     /// The reason for this is that these headers are too low-level and are directly handled by
     /// the underlying HTTP response system.

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -179,7 +179,7 @@ pub fn start<S>(request: &Request, subprotocol: Option<S>)
 
     let mut response = Response::text("");
     response.status_code = 101;
-    response.headers.push(("Upgrade".into(), "websocket".into()));
+    response.headers.push(("Upgrade".into(), "websocket".into()));      // FIXME: ignored ; see lib.rs
     if let Some(sp) = subprotocol {
         response.headers.push(("Sec-Websocket-Protocol".into(), sp.into()));
     }

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -179,7 +179,7 @@ pub fn start<S>(request: &Request, subprotocol: Option<S>)
 
     let mut response = Response::text("");
     response.status_code = 101;
-    response.headers.push(("Upgrade".into(), "websocket".into()));      // FIXME: ignored ; see lib.rs
+    response.headers.push(("Upgrade".into(), "websocket".into()));
     if let Some(sp) = subprotocol {
         response.headers.push(("Sec-Websocket-Protocol".into(), sp.into()));
     }


### PR DESCRIPTION
Also forbids the content-length and content-encoding headers. They were never intended to be accessible.