### PR TITLE
Add full_proxy()

### DIFF
--- a/examples/reverse-proxy.rs
+++ b/examples/reverse-proxy.rs
@@ -16,7 +16,7 @@ fn main() {
     println!("Now listening on localhost:8000");
 
     rouille::start_server("localhost:8000", move |request| {
-        rouille::proxy::proxy(&request, rouille::proxy::ProxyConfig {
+        rouille::proxy::full_proxy(&request, rouille::proxy::ProxyConfig {
             addr: "example.com:80",
             replace_host: Some("example.com".into()),
         }).unwrap()


### PR DESCRIPTION
Does the same as `proxy()` but can return a 502 or 504 response instead of an error.