### PR TITLE
ci: pin minimum supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rust:
     - nightly
     - stable
     - beta
+    - 1.18.0 # minimum supported version
 
 matrix:
   allow_failures:


### PR DESCRIPTION
It is good practice to pin the minimum version of Rust that you support
into your CI test loop to ensure it doesn't break or allow you to
advertise to users what the minimum supported version is.