### PR TITLE
doc for html method didn't use it

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -288,7 +288,7 @@ impl Response {
     ///
     /// ```
     /// use rouille::Response;
-    /// let response = Response::text("<p>hello <strong>world</strong></p>");
+    /// let response = Response::html("<p>hello <strong>world</strong></p>");
     /// ```
     #[inline]
     pub fn html<D>(content: D) -> Response where D: Into<String> {


### PR DESCRIPTION
Small doc fix to use the html method on the html method.