### PR TITLE
switch from rustc-serialize::base64 to base64 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ brotli = ["brotli2"]
 gzip = ["flate2"]
 
 [dependencies]
+base64 = "0.7.0"
 brotli2 = { version = "0.2.1", optional = true }
 chrono = "0.2.0"
 filetime = "0.1.10"

--- a/src/input/basic_http_auth.rs
+++ b/src/input/basic_http_auth.rs
@@ -17,7 +17,7 @@
 //! - In order to read a plain text body, see
 //!   [the `plain_text_body` function](fn.plain_text_body.html).
 
-use rustc_serialize::base64::FromBase64;
+use base64;
 use Request;
 
 /// Credentials returned by `basic_http_auth`.
@@ -71,7 +71,7 @@ pub fn basic_http_auth(request: &Request) -> Option<HttpAuthCredentials> {
     }
 
     let authvalue = match split.next() { None => return None, Some(v) => v };
-    let authvalue = match authvalue.from_base64() { Ok(v) => v, Err(_) => return None };
+    let authvalue = match base64::decode(authvalue) { Ok(v) => v, Err(_) => return None };
 
     let mut split = authvalue.splitn(2, |&c| c == b':');
     let login = match split.next() { Some(l) => l, None => return None };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
 
 #![deny(unsafe_code)]
 
+extern crate base64;
 #[cfg(feature = "brotli2")]
 extern crate brotli2;
 extern crate chrono;

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -69,6 +69,7 @@ pub use self::websocket::Message;
 pub use self::websocket::SendError;
 pub use self::websocket::Websocket;
 
+use base64;
 use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::error;
@@ -76,10 +77,6 @@ use std::fmt;
 use std::sync::mpsc;
 use std::vec::IntoIter as VecIntoIter;
 use sha1::Sha1;
-use rustc_serialize::base64::Config;
-use rustc_serialize::base64::Standard;
-use rustc_serialize::base64::Newline;
-use rustc_serialize::base64::ToBase64;
 
 use Request;
 use Response;
@@ -242,6 +239,5 @@ fn convert_key(input: &str) -> String {
     sha1.update(input.as_bytes());
     sha1.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
 
-    sha1.digest().bytes().to_base64(Config { char_set: Standard, pad: true,
-                                             line_length: None, newline: Newline::LF })
+    base64::encode_config(&sha1.digest().bytes(), base64::STANDARD)
 }


### PR DESCRIPTION
rustc-serialize is deprecated and upstream recommends users use serde.
The base64 support in rustc-serialize has been superceded by the base64
crate. refs #149.