### PR TITLE
modify router macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,8 @@
 //! The `Request` object itself provides some getters, but most advanced functionnalities are
 //! provided by other modules of this crate.
 //!
-//! - In order to dispatch between various code depending on the URL, you can use the `router!`
-//!   macro.
+//! - In order to dispatch between various code depending on the URL, you can use the
+//!   [`router!`](macro.router.html) macro.
 //! - In order to analyze the body of the request, like handling JSON input, form input, etc. you
 //!   can take a look at [the `input` module](input/index.html).
 //!


### PR DESCRIPTION
issue #155
- Modify `router!` to take a string `expr` url instead of a token sequence.
    - Allows arbitrary routes with numbers/periods/non-token-types
- Url parameters must be specified in the url string and in a trailing
  `identity: type` pair.
- Update usage/tests and examples

**problems:**
- ~~Uses a `HashMap` when pulling url params out of the url string so it's definitely slower than the current implementation. (only routes with url params)~~
- ~~Still need to get multiple param parsing working
    e.g. `(GET) ("/add/{a}/plus/{b}", a: u32, b: u32) ...`.
  The meat of the macro should work, but pattern matching that section is finicky and
  would likely require an ugly trailing separator for the no param variant:
    e.g. `(GET) ("/home",) ... `~~