### PR TITLE
add log function that uses the `log` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ gzip = ["flate2"]
 [dependencies]
 base64 = "0.7.0"
 brotli2 = { version = "0.2.1", optional = true }
-chrono = "0.2.0"
+chrono = "0.4.0"
 filetime = "0.1.10"
 flate2 = { version = "0.2.14", optional = true }
 multipart = { version = "0.5.1", default-features = false, features = ["server"] }
@@ -32,3 +32,4 @@ url = "1.2"
 
 [dev-dependencies]
 postgres = { version = "0.13", default-features = false }
+log = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ extern crate url;
 
 pub use assets::extension_to_mime;
 pub use assets::match_assets;
-pub use log::log;
+pub use log::{log, log_custom};
 pub use response::{Response, ResponseBody};
 pub use tiny_http::ReadWrite;
 


### PR DESCRIPTION
It'd be nice to have the option to incorporate request logging with an app's `env_logger` or whatever logging backend is being used.

The name is up for debate, not sure what else to call an alternate logging function.