### PR TITLE
Use std::result::Result in post_input

### DIFF
--- a/src/input/post.rs
+++ b/src/input/post.rs
@@ -485,6 +485,7 @@ macro_rules! post_input {
     ($request:expr, {$($field:ident: $ty:ty $({$config:expr})*),*$(,)*}) => ({
         use std::io::Read;
         use std::mem;
+        use std::result::Result;
         use $crate::Request;
         use $crate::input::post::DecodePostField;
         use $crate::input::post::PostFieldError;


### PR DESCRIPTION
Currently `post_input` does not explicitly use `std::result`. Instead, it uses the `Result` from the enclosing scope. As projects will frequently define their own `Result` type, this can result in some cryptic errors like in #156. I didn't immediatly see anywhere else this could be a problem in rouille, but let me know if there are any other places and I can add them to this PR.