### PR TITLE
Update `multipart` to 0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Dropped the use of [rustc-serialize](https://crates.io/rustc-serialize)
   in favor of using [serde](https://crates.io/serde).
+- Updated `multipart` to 0.13. The `input::multipart::get_multipart_input` function returns
+  types reexported from `multipart` which have small but breaking API changes.
 
 ## Version 1.0.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ brotli2 = { version = "0.2.1", optional = true }
 chrono = "0.4.0"
 filetime = "0.1.10"
 flate2 = { version = "0.2.14", optional = true }
-multipart = { version = "0.5.1", default-features = false, features = ["server"] }
+multipart = { version = "0.13.6", default-features = false, features = ["server"] }
 rand = "0.3.11"
 serde = "1"
 serde_derive = "1"

--- a/src/input/multipart.rs
+++ b/src/input/multipart.rs
@@ -82,7 +82,7 @@ pub struct Multipart<'a> {
 }
 
 impl<'a> Multipart<'a> {
-    pub fn next(&mut self) -> Option<MultipartField<RequestBody<'a>>> {
+    pub fn next(&mut self) -> Option<MultipartField<&mut InnerMultipart<RequestBody<'a>>>> {
         match self.inner.read_entry() {
             Ok(e) => e,
             _ => return None

--- a/src/input/post.rs
+++ b/src/input/post.rs
@@ -583,7 +583,7 @@ macro_rules! post_input {
 
                             match multipart_entry.data {
                                 multipart::MultipartData::Text(txt) => {
-                                    let decoded = match DecodePostField::from_field(config, txt) {
+                                    let decoded = match DecodePostField::from_field(config, &txt.text) {
                                         Ok(d) => d,
                                         Err(err) => return Err(PostError::Field {
                                             field: stringify!($field).into(),
@@ -599,9 +599,9 @@ macro_rules! post_input {
                                     };
                                 },
                                 multipart::MultipartData::File(f) => {
-                                    let name = f.filename().map(|n| n.to_owned());
+                                    let name = f.filename.as_ref().map(|n| n.to_owned());
                                     let name = name.as_ref().map(|n| &n[..]);
-                                    let mime = f.content_type().to_string();
+                                    let mime = f.content_type.to_string();
                                     let decoded = match DecodePostField::from_file(config, f, name, &mime) {
                                         Ok(d) => d,
                                         Err(err) => return Err(PostError::Field {


### PR DESCRIPTION
`multipart` 0.5.1 had a bug resulting in data corruption (appended newlines) in binary file uploads, which has been resolved in more recent versions.

Unfortunately, this is a breaking change to the re-exported `multipart` API and there are [more breaking changes](https://github.com/abonander/multipart/commit/874248b9eb79d4a5948cd6e0e7725fe1043c5600) to come.