### PR TITLE
Add option to run server with a threadpool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   in favor of using [serde](https://crates.io/serde).
 - Updated `multipart` to 0.13. The `input::multipart::get_multipart_input` function returns
   types reexported from `multipart` which have small but breaking API changes.
+- Update `Server` with an option to use a thread pool to process requests
 
 ## Version 1.0.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ term = "0.2"
 time = "0.1.31"
 tiny_http = "0.5.6"
 url = "1.2"
+threadpool = "1"
+num_cpus = "1"
 
 [dev-dependencies]
 postgres = { version = "0.13", default-features = false }


### PR DESCRIPTION
issue #167 
- Add crates: `threadpool`, `num_cpus`
- Add `start_server_with_pool` function that mirrors the existing
  `start_server` function
- Add an `Executor` instance to the `Server` to spawn server
  processes in either a `std::thread` or a `threadpool::ThreadPool`
- Change `Server::run` signature to take a reference instead of
  ownership so it mirrors `Server::poll` and can be chained
  after a call to `Server::pool_size`