### PR TITLE
Add Response::empty_204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   Previously, URL was eagerly decoded and thus would fail to match
   intended routes if special characters were used (such as ? or /).
   Now, individual matched components are decoded after matching.
+- Added `Response::empty_204`.
 
 ## Version 2.0.0
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -390,6 +390,24 @@ impl Response {
         }
     }
 
+    /// Builds an empty `Response` with a 204 status code.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rouille::Response;
+    /// let response = Response::empty_204();
+    /// ```
+    #[inline]
+    pub fn empty_204() -> Response {
+        Response {
+            status_code: 204,
+            headers: vec![],
+            data: ResponseBody::empty(),
+            upgrade: None,
+        }
+    }
+
     /// Builds an empty `Response` with a 400 status code.
     ///
     /// # Example


### PR DESCRIPTION
I wanted to return status code `204 No Content`. There are helpers for empty errors, but not for OK responses. This adds a helper for 204.

I noticed that people are using ugly workarounds like:

```
Response::empty_404().with_status_code(204).without_header("Content-Length")
```
(from https://github.com/tomaka/rouille/issues/150 )

If you want I would be willing to refactor the different `empty_*` functions to use a common private function.