### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Version [Unreleased]
 
+## Version 2.1.0
+
 - Replace `flate2` with `deflate`
 - Fixed handling of url-encoded path components in route!() macro. 
   Previously, URL was eagerly decoded and thus would fail to match

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rouille"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/tomaka/rouille"


### PR DESCRIPTION
The reason for the bump is the inclusion of recent patches that
are critical to some applications (SSL and URL-encoded path
components)