### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
     - nightly
     - stable
     - beta
-    - 1.18.0 # minimum supported version
+    - 1.20.0 # minimum supported version
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,24 +17,24 @@ gzip = ["deflate"]
 ssl = ["tiny_http/ssl"]
 
 [dependencies]
-base64 = "0.7.0"
-brotli2 = { version = "0.2.1", optional = true }
+base64 = "0.9.0"
+brotli2 = { version = "0.3.2", optional = true }
 chrono = "0.4.0"
 filetime = "0.1.10"
 deflate = { version = "0.7", optional = true, features = ["gzip"] }
 multipart = { version = "0.13.6", default-features = false, features = ["server"] }
-rand = "0.3.11"
+rand = "0.4.2"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-sha1 = "0.2.0"
-term = "0.2"
+sha1 = "0.6.0"
+term = "0.5.1"
 time = "0.1.31"
-tiny_http = "0.5.6"
+tiny_http = "0.6.0"
 url = "1.2"
 threadpool = "1"
 num_cpus = "1"
 
 [dev-dependencies]
-postgres = { version = "0.13", default-features = false }
-log = "0.3"
+postgres = { version = "0.15.2", default-features = false }
+log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ ssl = ["tiny_http/ssl"]
 base64 = "0.9.0"
 brotli2 = { version = "0.3.2", optional = true }
 chrono = "0.4.0"
-filetime = "0.1.10"
+filetime = "0.2.0"
 deflate = { version = "0.7", optional = true, features = ["gzip"] }
 multipart = { version = "0.13.6", default-features = false, features = ["server"] }
 rand = "0.4.2"

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -121,7 +121,7 @@ pub fn match_assets<P: ?Sized>(request: &Request, path: &P) -> Response
     };
 
     let etag: String = (fs::metadata(&potential_file)
-        .map(|meta| filetime::FileTime::from_last_modification_time(&meta).seconds_relative_to_1970())
+        .map(|meta| filetime::FileTime::from_last_modification_time(&meta).unix_seconds() as u64)
         .unwrap_or(time::now().tm_nsec as u64)
         ^ 0xd3f40305c9f8e911u64).to_string();
 


### PR DESCRIPTION
Only dependency this didn't update is `multipart` from 0.13.6 into 0.14.2. It requires better understanding of how both `multipart` and `rouille` internals work.