### PR TITLE
Add allow unused_imports before import of AsciiExt trait

### DIFF
--- a/src/content_encoding.rs
+++ b/src/content_encoding.rs
@@ -7,10 +7,14 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use std::ascii::AsciiExt;
 use std::str;
 use Request;
 use Response;
+
+// The AsciiExt import is needed for Rust older than 1.23.0. These two lines can
+// be removed when supporting older Rust is no longer needed.
+#[allow(unused_imports)]
+use std::ascii::AsciiExt;
 
 /// Applies content encoding to the response.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,12 @@ use std::slice::Iter as SliceIter;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
-use std::ascii::AsciiExt;
 use std::fmt;
+
+// The AsciiExt import is needed for Rust older than 1.23.0. These two lines can
+// be removed when supporting older Rust is no longer needed.
+#[allow(unused_imports)]
+use std::ascii::AsciiExt;
 
 pub mod cgi;
 pub mod content_encoding;

--- a/src/response.rs
+++ b/src/response.rs
@@ -7,7 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::io;
 use std::io::Cursor;
@@ -19,6 +18,11 @@ use serde_json;
 use url::percent_encoding;
 use Request;
 use Upgrade;
+
+// The AsciiExt import is needed for Rust older than 1.23.0. These two lines can
+// be removed when supporting older Rust is no longer needed.
+#[allow(unused_imports)]
+use std::ascii::AsciiExt;
 
 /// Contains a prototype of a response.
 ///

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -70,13 +70,17 @@ pub use self::websocket::SendError;
 pub use self::websocket::Websocket;
 
 use base64;
-use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::error;
 use std::fmt;
 use std::sync::mpsc;
 use std::vec::IntoIter as VecIntoIter;
 use sha1::Sha1;
+
+// The AsciiExt import is needed for Rust older than 1.23.0. These two lines can
+// be removed when supporting older Rust is no longer needed.
+#[allow(unused_imports)]
+use std::ascii::AsciiExt;
 
 use Request;
 use Response;


### PR DESCRIPTION
The AsciiExt trait was removed in Rust 1.23.0 and no longer needed for newer Rust. However, to support older Rust versions the trait is needed. This change keeps the import of trait and removes the warning on newer Rusts.

This is the recommended way to deal with the issue in Rust 1.23 release notes: https://blog.rust-lang.org/2018/01/04/Rust-1.23.html