### PR TITLE
Add module documentation to content_encoding.

### DIFF
--- a/src/content_encoding.rs
+++ b/src/content_encoding.rs
@@ -7,6 +7,29 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
+//! Apply content encodings (such as gzip compression) to the response.
+//!
+//! This module provides access to the content encodings supported by a request as well as
+//! a function to automatically apply common content encodings to a response.
+//! # Basic example
+//!
+//! Here is a basic example showing how to use content encodings:
+//!
+//! ```
+//! use rouille::Request;
+//! use rouille::Response;
+//! use rouille::content_encoding;
+//!
+//! fn handle_request(request: &Request) -> Response {
+//!     let text = String::new();
+//!     for encoding in content_encoding::accepted_content_encodings(request) {
+//!         text.push_str(encoding);
+//!         text.push('\n');
+//!     }
+//!     let response = Response::text(&text);
+//!     content_encoding::apply(response)
+//! }
+//! ```
 use std::str;
 use Request;
 use Response;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,10 @@
 //!
 //! In order to serve static files, take a look at
 //! [the `match_assets` function](fn.match_assets.html).
+//!
+//! In order to apply content encodings (including compression such as gzip or deflate), see
+//! the [content_encoding module](content_encoding/index.html), and specifically the
+//! [content_encoding::apply](content_encoding/fn.apply.html) function.
 
 #![deny(unsafe_code)]
 


### PR DESCRIPTION
Also added a note to the crate-level documentation pointing readers to the `content_encoding` module.