### PR TITLE
Fix Travis: Update minimum Rust version to 1.22.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
     - nightly
     - stable
     - beta
-    - 1.20.0 # minimum supported version
+    - 1.22.0 # minimum supported version
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = "0.4.0"
 filetime = "0.2.0"
 deflate = { version = "0.7", optional = true, features = ["gzip"] }
 multipart = { version = "0.13.6", default-features = false, features = ["server"] }
-rand = "0.4.2"
+rand = "0.5"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/src/session.rs
+++ b/src/session.rs
@@ -38,6 +38,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use rand;
 use rand::Rng;
+use rand::distributions::Alphanumeric;
 
 use Request;
 use Response;
@@ -115,7 +116,7 @@ impl<'r> Session<'r> {
 pub fn generate_session_id() -> String {
     // 5e+114 possibilities is reasonable.
     rand::OsRng::new().expect("Failed to initialize OsRng")     // TODO: <- handle that?
-                      .gen_ascii_chars()
+                      .sample_iter(&Alphanumeric)
                       .filter(|&c| (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
                                    (c >= '0' && c <= '9'))
                       .take(64).collect::<String>()


### PR DESCRIPTION
The [unicode-normalization](https://github.com/unicode-rs/unicode-normalization#readme) crate requires Rust 1.21.0 and rand 0.5 requires Rust 1.22.0. So, update TravisCI config to test with 1.22.0.

This PR should fix the failing TravisCI jobs of earlier PRs.

While there, update dependency of rand to 0.5.

