### PR TITLE
Update rng used to generate session id

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -115,9 +115,7 @@ impl<'r> Session<'r> {
 /// that could need to be escaped.
 pub fn generate_session_id() -> String {
     // 5e+114 possibilities is reasonable.
-    rand::OsRng::new().expect("Failed to initialize OsRng")     // TODO: <- handle that?
-                      .sample_iter(&Alphanumeric)
-                      .filter(|&c| (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-                                   (c >= '0' && c <= '9'))
-                      .take(64).collect::<String>()
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(64).collect::<String>()
 }


### PR DESCRIPTION
Version 5.0 of rand changed the algorithm
behind `ThreadRng` to a cryptographicly secure one.
https://docs.rs/rand/0.5.0/rand/rngs/struct.ThreadRng.html

`ThreadRng` should both be faster and more fault tolerant
than `OsRng`.

Also removed the filter after the generation of random data.
`Alphanumeric` only generates characters in the range 'a'-'z',
'A'-'Z' and '0'-'9', so the filter was a no-op.