### PR TITLE
Fix charset value and missing application/json charset

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -299,7 +299,7 @@ impl Response {
     pub fn html<D>(content: D) -> Response where D: Into<String> {
         Response {
             status_code: 200,
-            headers: vec![("Content-Type".into(), "text/html; charset=utf8".into())],
+            headers: vec![("Content-Type".into(), "text/html; charset=utf-8".into())],
             data: ResponseBody::from_string(content),
             upgrade: None,
         }
@@ -317,7 +317,7 @@ impl Response {
     pub fn svg<D>(content: D) -> Response where D: Into<String> {
         Response {
             status_code: 200,
-            headers: vec![("Content-Type".into(), "image/svg+xml; charset=utf8".into())],
+            headers: vec![("Content-Type".into(), "image/svg+xml; charset=utf-8".into())],
             data: ResponseBody::from_string(content),
             upgrade: None,
         }
@@ -335,7 +335,7 @@ impl Response {
     pub fn text<S>(text: S) -> Response where S: Into<String> {
         Response {
             status_code: 200,
-            headers: vec![("Content-Type".into(), "text/plain; charset=utf8".into())],
+            headers: vec![("Content-Type".into(), "text/plain; charset=utf-8".into())],
             data: ResponseBody::from_string(text),
             upgrade: None,
         }

--- a/src/response.rs
+++ b/src/response.rs
@@ -368,7 +368,7 @@ impl Response {
 
         Response {
             status_code: 200,
-            headers: vec![("Content-Type".into(), "application/json".into())],
+            headers: vec![("Content-Type".into(), "application/json; charset=utf-8".into())],
             data: ResponseBody::from_data(data),
             upgrade: None,
         }


### PR DESCRIPTION
Previously responses had invalid 'utf8' charset the correct form is 'utf-8'.
I also added missing utf-8 charset to application/json which is used in Response::json function.