### PR TITLE
bump minimum rust version to 1.24.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
     - nightly
     - stable
     - beta
-    - 1.22.0 # minimum supported version
+    - 1.24.1 # minimum supported version
 
 matrix:
   allow_failures:


### PR DESCRIPTION
This bumps the minimum rust version to 1.24.1. This isn't done
directly for this project, but one of your dependencies,
multipart, uses lazy_static, and there is a soundness bug that
was fixed in 1.2.0 and rust 1.24.1. In order to avoid this bug
in multipart, we need to bump your minimum version as well.