### PR TITLE
Add Server.poll_timeout method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,33 @@ impl<F> Server<F> where F: Send + Sync + 'static + Fn(&Request) -> Response {
         }
     }
 
+    /// Same as `poll()` but blocks for at most `duration` before returning.
+    ///
+    /// This function can be used implement a custom server loop in a more CPU-efficient manner
+    /// than calling `poll`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rouille::Server;
+    /// use rouille::Response;
+    ///
+    /// let server = Server::new("localhost:0", |request| {
+    ///     Response::text("hello world")
+    /// }).unwrap();
+    /// let mut run = true;
+    /// while run {
+    ///     server.poll_timeout(std::time::Duration::from_millis(100));
+    /// }
+    /// ```
+
+    #[inline]
+    pub fn poll_timeout(&self, dur: std::time::Duration) {
+        while let Ok(Some(request)) = self.server.recv_timeout(dur) {
+            self.process(request);
+        }
+    }
+
     // Internal function, called when we got a request from tiny-http that needs to be processed.
     fn process(&self, request: tiny_http::Request) {
         // We spawn a thread so that requests are processed in parallel.


### PR DESCRIPTION
As per #200 I was looking for a way to have Rouille run in a thread, in a way which I could interrupt when the application shutdown.

Just calling `poll` in a loop seemed very wasteful. For my purposes just calling `poll` with a short (~10ms or so) sleep was okay, but seemed like it'd be easy/useful to add a `poll_timeout` method consistent with tiny_http's `recv_timeout`