### PR TITLE
Stoppable server

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,8 +415,15 @@ impl<F> Server<F> where F: Send + Sync + 'static + Fn(&Request) -> Response {
     /// # Example
     ///
     /// ```no_run
-    /// let mut run = true;
-    /// while run {
+    /// use rouille::Server;
+    /// use rouille::Response;
+    ///
+    /// let server = Server::new("localhost:0", |request| {
+    ///     Response::text("hello world")
+    /// }).unwrap();
+    /// println!("Listening on {:?}", server.server_addr());
+    ///
+    /// loop {
     ///     server.poll_timeout(std::time::Duration::from_millis(100));
     /// }
     /// ```


### PR DESCRIPTION
## Summary
Added the `Server::stoppable()` function which provides a method for gracefully stopping a `Server`.

## Motivation
There was obvious way to gracefully stop a Rouille server, and I ended up implementing this code in my own project. Since it's fairly simple and a useful feature I figured I would contribute it back.

See the provided documentation example for basic usage.