### PR TITLE
Upgrade MSRV, dependencies, edition, whitespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
     - nightly
     - stable
     - beta
-    - 1.24.1 # minimum supported version
+    - 1.34.2 # minimum supported version
 
 matrix:
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Version [Unreleased]
+- Bump minimum supported Rust version to 1.34.2
+- embedded, exposed `url` version increased to 2.0
 
 ## Version 2.2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ gzip = ["deflate"]
 ssl = ["tiny_http/ssl"]
 
 [dependencies]
-base64 = "0.9.0"
+base64 = "0.10"
 brotli2 = { version = "0.3.2", optional = true }
 chrono = "0.4.0"
 filetime = "0.2.0"
 deflate = { version = "0.7", optional = true, features = ["gzip"] }
 multipart = { version = "0.16", default-features = false, features = ["server"] }
 percent-encoding = "2"
-rand = "0.5"
+rand = "0.7"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ brotli2 = { version = "0.3.2", optional = true }
 chrono = "0.4.0"
 filetime = "0.2.0"
 deflate = { version = "0.7", optional = true, features = ["gzip"] }
-multipart = { version = "0.15", default-features = false, features = ["server"] }
+multipart = { version = "0.16", default-features = false, features = ["server"] }
+percent-encoding = "2"
 rand = "0.5"
 serde = "1"
 serde_derive = "1"
@@ -31,7 +32,7 @@ sha1 = "0.6.0"
 term = "0.5.1"
 time = "0.1.31"
 tiny_http = "0.6.0"
-url = "1.2"
+url = "2"
 threadpool = "1"
 num_cpus = "1"
 

--- a/src/content_encoding.rs
+++ b/src/content_encoding.rs
@@ -11,11 +11,6 @@ use std::str;
 use Request;
 use Response;
 
-// The AsciiExt import is needed for Rust older than 1.23.0. These two lines can
-// be removed when supporting older Rust is no longer needed.
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
-
 /// Applies content encoding to the response.
 ///
 /// Analyzes the `Accept-Encoding` header of the request. If one of the encodings is recognized and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,14 @@ extern crate sha1;
 extern crate time;
 extern crate tiny_http;
 pub extern crate url;
+pub extern crate percent_encoding;
 extern crate threadpool;
 extern crate num_cpus;
+
+// https://github.com/servo/rust-url/blob/e121d8d0aafd50247de5f5310a227ecb1efe6ffe/percent_encoding/lib.rs#L126
+pub const DEFAULT_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
+    .add(b' ').add(b'"').add(b'#').add(b'<').add(b'>')
+    .add(b'`').add(b'?').add(b'{').add(b'}');
 
 pub use assets::extension_to_mime;
 pub use assets::match_assets;
@@ -364,13 +370,13 @@ impl<F> Server<F> where F: Send + Sync + 'static + Fn(&Request) -> Response {
     }
 
     /// Creates a new thread for the server that can be gracefully stopped later.
-    /// 
+    ///
     /// This function returns a tuple of a `JoinHandle` and a `Sender`.
     /// You must call `JoinHandle::join()` otherwise the server will not run until completion.
     /// The server can be stopped at will by sending it an empty `()` message from another thread.
     /// There may be a maximum of a 1 second delay between sending the stop message and the server
     /// stopping. This delay may be shortened in future.
-    /// 
+    ///
     /// ```no_run
     /// use std::thread;
     /// use std::time::Duration;
@@ -382,13 +388,13 @@ impl<F> Server<F> where F: Send + Sync + 'static + Fn(&Request) -> Response {
     /// }).unwrap();
     /// println!("Listening on {:?}", server.server_addr());
     /// let (handle, sender) = server.stoppable();
-    /// 
+    ///
     /// // Stop the server in 3 seconds
     /// thread::spawn(move || {
     ///     thread::sleep(Duration::from_secs(3));
     ///     sender.send(()).unwrap();
     /// });
-    /// 
+    ///
     /// // Block the main thread until the server is stopped
     /// handle.join().unwrap();
     /// ```
@@ -406,7 +412,7 @@ impl<F> Server<F> where F: Send + Sync + 'static + Fn(&Request) -> Response {
 
         (handle, tx)
     }
-  
+
     /// Same as `poll()` but blocks for at most `duration` before returning.
     ///
     /// This function can be used implement a custom server loop in a more CPU-efficient manner
@@ -756,7 +762,7 @@ impl Request {
             url
         };
 
-        url::percent_encoding::percent_decode(url).decode_utf8_lossy().into_owned()
+        percent_encoding::percent_decode(url).decode_utf8_lossy().into_owned()
     }
 
     /// Returns the value of a GET parameter.
@@ -776,7 +782,7 @@ impl Request {
             Some(e) => &get_params[param .. e + param],
         };
 
-        Some(url::percent_encoding::percent_decode(value.replace("+", " ").as_bytes()).decode_utf8_lossy().into_owned())
+        Some(percent_encoding::percent_decode(value.replace("+", " ").as_bytes()).decode_utf8_lossy().into_owned())
     }
 
     /// Returns the value of a header of the request.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,10 +101,6 @@ use std::sync::mpsc;
 use std::thread;
 use std::fmt;
 
-// The AsciiExt import is needed for Rust older than 1.23.0. These two lines can
-// be removed when supporting older Rust is no longer needed.
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
 
 pub mod cgi;
 pub mod content_encoding;

--- a/src/response.rs
+++ b/src/response.rs
@@ -15,7 +15,7 @@ use std::fs::File;
 use std::fmt;
 use serde;
 use serde_json;
-use url::percent_encoding;
+use percent_encoding;
 use Request;
 use Upgrade;
 
@@ -617,7 +617,7 @@ impl Response {
     pub fn with_content_disposition_attachment(mut self, filename: &str) -> Response {
         // The name must be percent-encoded.
         let name = percent_encoding::percent_encode(filename.as_bytes(),
-                                                    percent_encoding::DEFAULT_ENCODE_SET);
+                                                    super::DEFAULT_ENCODE_SET);
 
         // If you find a more elegant way to do the thing below, don't hesitate to open a PR
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -19,11 +19,6 @@ use percent_encoding;
 use Request;
 use Upgrade;
 
-// The AsciiExt import is needed for Rust older than 1.23.0. These two lines can
-// be removed when supporting older Rust is no longer needed.
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
-
 /// Contains a prototype of a response.
 ///
 /// The response is only sent to the client when you return the `Response` object from your

--- a/src/router.rs
+++ b/src/router.rs
@@ -155,7 +155,7 @@ macro_rules! router {
     (__check_parse_pattern $request_url_str:ident, $url_pattern:expr => $handle:expr ; $($param:ident: $param_type:ty),*) => {
         {
             let request_url = $request_url_str.split("/")
-                .map(|s| $crate::url::percent_encoding::percent_decode(s.as_bytes()).decode_utf8_lossy().into_owned())
+                .map(|s| $crate::percent_encoding::percent_decode(s.as_bytes()).decode_utf8_lossy().into_owned())
                 .collect::<Vec<_>>();
             let url_pattern = $url_pattern.split("/").collect::<Vec<_>>();
             if request_url.len() != url_pattern.len() {
@@ -299,7 +299,7 @@ macro_rules! router {
             let pat_end = url.find('/').unwrap_or(url.len());
             let rest_url = &url[pat_end..];
 
-            if let Ok($p) = $crate::url::percent_encoding::percent_decode(url[0 .. pat_end].as_bytes())
+            if let Ok($p) = $crate::percent_encoding::percent_decode(url[0 .. pat_end].as_bytes())
                 .decode_utf8_lossy().parse() {
                 let $p: $t = $p;
                 router!(__check_pattern rest_url $value $($rest)*)
@@ -575,7 +575,7 @@ mod tests {
     fn encoded() {
         let request = Request::fake_http("GET", "/hello/%3Fa/test", vec![], vec![]);
 
-        assert_eq!("?a", router!(request, 
+        assert_eq!("?a", router!(request,
            (GET) ["/hello/{val}/test", val: String] => { val },
            _ => String::from("")));
     }
@@ -584,7 +584,7 @@ mod tests {
     fn encoded_old() {
         let request = Request::fake_http("GET", "/hello/%3Fa/test", vec![], vec![]);
 
-        assert_eq!("?a", router!(request, 
+        assert_eq!("?a", router!(request,
            (GET) (/hello/{val: String}/test) => { val },
            _ => String::from("")));
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -115,9 +115,14 @@ impl<'r> Session<'r> {
 /// that could need to be escaped.
 pub fn generate_session_id() -> String {
     // 5e+114 possibilities is reasonable.
-    rand::OsRng::new().expect("Failed to initialize OsRng")     // TODO: <- handle that?
+    rand::thread_rng()
                       .sample_iter(&Alphanumeric)
                       .filter(|&c| (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
                                    (c >= '0' && c <= '9'))
                       .take(64).collect::<String>()
+}
+
+#[test]
+fn test_generate_session_id() {
+    assert!(generate_session_id().len() >= 32);
 }

--- a/src/try_or_400.rs
+++ b/src/try_or_400.rs
@@ -55,7 +55,7 @@ pub struct ErrJson<'a> {
 
 impl<'a> ErrJson<'a> {
     pub fn from_err<E: ?Sized + Error>(err: &'a E) -> ErrJson<'a> {
-        let cause = err.cause().map(ErrJson::from_err).map(Box::new);
+        let cause = err.source().map(ErrJson::from_err).map(Box::new);
         ErrJson { description: err.description(), cause }
     }
 }

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -45,7 +45,7 @@
 //!   have to enumerate the protocols with `requested_protocols()` and choose one.
 //!
 //! # Example
-//! 
+//!
 //! ```
 //! # #[macro_use] extern crate rouille;
 //! use std::sync::Mutex;
@@ -76,11 +76,6 @@ use std::fmt;
 use std::sync::mpsc;
 use std::vec::IntoIter as VecIntoIter;
 use sha1::Sha1;
-
-// The AsciiExt import is needed for Rust older than 1.23.0. These two lines can
-// be removed when supporting older Rust is no longer needed.
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
 
 use Request;
 use Response;
@@ -194,7 +189,7 @@ pub fn start<S>(request: &Request, subprotocol: Option<S>)
 ///
 /// ```
 /// use rouille::websocket;
-/// 
+///
 /// # let request: rouille::Request = return;
 /// for protocol in websocket::requested_protocols(&request) {
 ///     // ...


### PR DESCRIPTION
 * The build is already broken on the specified Minimum Supported Rust Version, because `regex` and `tempfile` has moved underneath. This is very hard to resolve with pins, because `regex` fights back. This probably requires them making changes. Upgrade MSRV 1.34.2 instead.
 * Upgrade `multipart`, `url` (exported), `rand` and `base64`. `url` (via. `percent_encoding`) requires >=1.33. `rand` requires >=1.32.
 * Remove compatibility hacks with 1.24.1, and other deprecated usages.
 * Run `rustfmt` and `dos2unix` to make everything consistent, such that we can...
 * Move to `edition = "2018"`, via. `cargo fix --edition`, as we now require a compiler where this is super stable.