### PR TITLE
Fix try! deprecation warnings

### DIFF
--- a/src/cgi.rs
+++ b/src/cgi.rs
@@ -128,10 +128,10 @@ impl CgiRun for Command {
 
         // TODO: `HTTP_` env vars with the headers
 
-        let mut child = try!(self.spawn());
+        let mut child = self.spawn()?;
 
         if let Some(mut body) = request.data() {
-            try!(io::copy(&mut body, child.stdin.as_mut().unwrap()));
+            io::copy(&mut body, child.stdin.as_mut().unwrap())?;
         } else {
             return Err(CgiError::BodyAlreadyExtracted);
         }
@@ -142,7 +142,7 @@ impl CgiRun for Command {
             let mut headers = Vec::new();
             let mut status_code = 200;
             for header in stdout.by_ref().lines() {
-                let header = try!(header);
+                let header = header?;
                 if header.is_empty() { break; }
     
                 let mut splits = header.splitn(2, ':');

--- a/src/input/plain.rs
+++ b/src/input/plain.rs
@@ -124,7 +124,7 @@ pub fn plain_text_body_with_limit(request: &Request, limit: usize)
     };
 
     let mut out = Vec::new();
-    try!(body.take(limit.saturating_add(1) as u64).read_to_end(&mut out));
+    body.take(limit.saturating_add(1) as u64).read_to_end(&mut out)?;
     if out.len() > limit {
         return Err(PlainTextError::LimitExceeded);
     }

--- a/src/input/post.rs
+++ b/src/input/post.rs
@@ -410,14 +410,14 @@ impl DecodePostField<()> for bool {
 
 impl<T, C> DecodePostField<C> for Vec<T> where T: DecodePostField<C> {
     fn from_field(config: C, content: &str) -> Result<Self, PostFieldError> {
-        Ok(vec![try!(DecodePostField::from_field(config, content))])
+        Ok(vec![DecodePostField::from_field(config, content)?])
     }
 
     fn from_file<R>(config: C, file: R, filename: Option<&str>, mime: &str)
                     -> Result<Self, PostFieldError>
         where R: BufRead
     {
-        Ok(vec![try!(DecodePostField::from_file(config, file, filename, mime))])
+        Ok(vec![DecodePostField::from_file(config, file, filename, mime)?])
     }
 
     fn merge_multiple(mut self, mut existing: Vec<T>) -> Result<Vec<T>, PostFieldError> {
@@ -462,7 +462,7 @@ impl DecodePostField<()> for BufferedFile {
         where R: BufRead
     {
         let mut out = Vec::new();
-        try!(file.read_to_end(&mut out));
+        file.read_to_end(&mut out)?;
 
         Ok(BufferedFile {
             data: out,
@@ -499,7 +499,7 @@ macro_rules! post_input {
             match existing {
                 a @ &mut Some(_) => {
                     let extracted = a.take().unwrap();
-                    let merged = try!(extracted.merge_multiple(new));
+                    let merged = extracted.merge_multiple(new)?;
                     *a = Some(merged);
                 },
                 a @ &mut None => *a = Some(new),
@@ -520,7 +520,7 @@ macro_rules! post_input {
                     // TODO: DDoSable server if body is too large?
                     let mut out = Vec::new();       // TODO: with_capacity()?
                     if let Some(mut b) = request.data() {
-                        try!(b.read_to_end(&mut out));
+                        b.read_to_end(&mut out)?;
                     } else {
                         return Err(PostError::BodyAlreadyExtracted);
                     }
@@ -660,7 +660,7 @@ pub fn raw_urlencoded_post_input(request: &Request) -> Result<Vec<(String, Strin
         // TODO: DDoSable server if body is too large?
         let mut out = Vec::new();       // TODO: with_capacity()?
         if let Some(mut b) = request.data() {
-            try!(b.read_to_end(&mut out));
+            b.read_to_end(&mut out)?;
         } else {
             return Err(PostError::BodyAlreadyExtracted);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ impl<F> Server<F> where F: Send + Sync + 'static + Fn(&Request) -> Response {
     pub fn new<A>(addr: A, handler: F) -> Result<Server<F>, Box<dyn Error + Send + Sync>>
         where A: ToSocketAddrs
     {
-        let server = try!(tiny_http::Server::http(addr));
+        let server = tiny_http::Server::http(addr)?;
         Ok(Server {
             server,
             executor: Executor::Threaded,
@@ -323,7 +323,7 @@ impl<F> Server<F> where F: Send + Sync + 'static + Fn(&Request) -> Response {
             certificate,
             private_key,
         };
-        let server = try!(tiny_http::Server::https(addr, ssl_config));
+        let server = tiny_http::Server::https(addr, ssl_config)?;
         Ok(Server {
             server,
             executor: Executor::Threaded,

--- a/src/websocket/websocket.rs
+++ b/src/websocket/websocket.rs
@@ -79,7 +79,7 @@ impl Websocket {
             None => return Err(SendError::Closed),
         };
 
-        try!(send(data.as_bytes(), Write::by_ref(socket), 0x1));
+        send(data.as_bytes(), Write::by_ref(socket), 0x1)?;
         Ok(())
     }
 
@@ -95,7 +95,7 @@ impl Websocket {
             None => return Err(SendError::Closed),
         };
 
-        try!(send(data, Write::by_ref(socket), 0x2));
+        send(data, Write::by_ref(socket), 0x2)?;
         Ok(())
     }
 
@@ -312,11 +312,11 @@ fn send<W: Write>(data: &[u8], mut dest: W, opcode: u8) -> io::Result<()> {
     // Write the opcode
     assert!(opcode <= 0xf);
     let first_byte = 0x80 | opcode;
-    try!(dest.write_all(&[first_byte]));
+    dest.write_all(&[first_byte])?;
 
     // Write the length
     if data.len() >= 65536 {
-        try!(dest.write_all(&[127u8]));
+        dest.write_all(&[127u8])?;
         let len = data.len() as u64;
         assert!(len < 0x8000_0000_0000_0000);
         let len1 = (len >> 56) as u8;
@@ -327,21 +327,21 @@ fn send<W: Write>(data: &[u8], mut dest: W, opcode: u8) -> io::Result<()> {
         let len6 = (len >> 16) as u8;
         let len7 = (len >> 8) as u8;
         let len8 = (len >> 0) as u8;
-        try!(dest.write_all(&[len1, len2, len3, len4, len5, len6, len7, len8]));
+        dest.write_all(&[len1, len2, len3, len4, len5, len6, len7, len8])?;
 
     } else if data.len() >= 126 {
-        try!(dest.write_all(&[126u8]));
+        dest.write_all(&[126u8])?;
         let len = data.len() as u16;
         let len1 = (len >> 8) as u8;
         let len2 = len as u8;
-        try!(dest.write_all(&[len1, len2]));
+        dest.write_all(&[len1, len2])?;
 
     } else {
-        try!(dest.write_all(&[data.len() as u8]));
+        dest.write_all(&[data.len() as u8])?;
     }
 
     // Write the data
-    try!(dest.write_all(data));
-    try!(dest.flush());
+    dest.write_all(data)?;
+    dest.flush()?;
     Ok(())
 }


### PR DESCRIPTION
Recent Rust version 1.39 marked the `try!` macro as deprecated. This patch replaces all usages of the `try!` macro with the recommended question mark operator.