### PR TITLE
Remove dependency on byteorder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ tiny_http = "0.8.1"
 url = "2"
 threadpool = "1"
 num_cpus = "1"
-byteorder = "1.4.3"
 
 [dev-dependencies]
 postgres = { version = "0.19", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@ extern crate rand;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate byteorder;
 extern crate num_cpus;
 pub extern crate percent_encoding;
 extern crate serde_json;

--- a/src/websocket/low_level.rs
+++ b/src/websocket/low_level.rs
@@ -24,8 +24,6 @@
 //! - Each message is made of one or more *frames*. See https://tools.ietf.org/html/rfc6455#section-5.4.
 //! - Each frame can be received progressively, where each packet is an `Element` object (below).
 
-use byteorder::{ByteOrder, NetworkEndian};
-
 /// A websocket element decoded from the data given to `StateMachine::feed`.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Element<'a> {
@@ -111,7 +109,7 @@ impl StateMachine {
 // take the hit of adding another dependency.
 fn read_u16_be<'a, T: Iterator<Item = &'a u8>>(input: &mut T) -> u16 {
     let buf: [u8; 2] = [*input.next().unwrap(), *input.next().unwrap()];
-    NetworkEndian::read_u16(&buf)
+    u16::from_be_bytes(buf)
 }
 
 fn read_u32_be<'a, T: Iterator<Item = &'a u8>>(input: &mut T) -> u32 {
@@ -121,7 +119,7 @@ fn read_u32_be<'a, T: Iterator<Item = &'a u8>>(input: &mut T) -> u32 {
         *input.next().unwrap(),
         *input.next().unwrap(),
     ];
-    NetworkEndian::read_u32(&buf)
+    u32::from_be_bytes(buf)
 }
 
 fn read_u64_be<'a, T: Iterator<Item = &'a u8>>(input: &mut T) -> u64 {
@@ -135,7 +133,7 @@ fn read_u64_be<'a, T: Iterator<Item = &'a u8>>(input: &mut T) -> u64 {
         *input.next().unwrap(),
         *input.next().unwrap(),
     ];
-    NetworkEndian::read_u64(&buf)
+    u64::from_be_bytes(buf)
 }
 
 /// Iterator to the list of elements that were received.

--- a/src/websocket/websocket.rs
+++ b/src/websocket/websocket.rs
@@ -7,7 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-use byteorder::{NetworkEndian, WriteBytesExt};
 use std::io;
 use std::io::Write;
 use std::mem;
@@ -347,11 +346,11 @@ fn send<W: Write>(data: &[u8], mut dest: W, opcode: u8) -> io::Result<()> {
         dest.write_all(&[127u8])?;
         let len = data.len() as u64;
         assert!(len < 0x8000_0000_0000_0000);
-        dest.write_u64::<NetworkEndian>(len)?;
+        dest.write_all(&len.to_be_bytes())?;
     } else if data.len() >= 126 {
         dest.write_all(&[126u8])?;
         let len = data.len() as u16;
-        dest.write_u16::<NetworkEndian>(len)?;
+        dest.write_all(&len.to_be_bytes())?;
     } else {
         dest.write_all(&[data.len() as u8])?;
     }


### PR DESCRIPTION
https://github.com/BurntSushi/byteorder#alternatives

> Note that as of Rust 1.32, the standard numeric types provide built-in methods like to_le_bytes and from_le_bytes, which support some of the same use cases.

