### PR TITLE
Server cannot be stopped under load

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,14 +458,12 @@ where
     #[inline]
     pub fn stoppable(self) -> (thread::JoinHandle<()>, mpsc::Sender<()>) {
         let (tx, rx) = mpsc::channel();
-        let handle = thread::spawn(move || {
-            loop {
-                // In order to reduce CPU load wait 1s for a recv before looping again
-                while let Ok(Some(request)) = self.server.recv_timeout(Duration::from_secs(1)) {
-                    self.process(request);
-                    if rx.try_recv().is_ok() {
-                        return;
-                    }
+        let handle = thread::spawn(move || loop {
+            // In order to reduce CPU load wait 1s for a recv before looping again
+            while let Ok(Some(request)) = self.server.recv_timeout(Duration::from_secs(1)) {
+                self.process(request);
+                if rx.try_recv().is_ok() {
+                    return;
                 }
             }
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,10 +459,13 @@ where
     pub fn stoppable(self) -> (thread::JoinHandle<()>, mpsc::Sender<()>) {
         let (tx, rx) = mpsc::channel();
         let handle = thread::spawn(move || {
-            while rx.try_recv().is_err() {
+            loop {
                 // In order to reduce CPU load wait 1s for a recv before looping again
                 while let Ok(Some(request)) = self.server.recv_timeout(Duration::from_secs(1)) {
                     self.process(request);
+                    if rx.try_recv().is_ok() {
+                        return;
+                    }
                 }
             }
         });


### PR DESCRIPTION
If server constantly receives requests (at least a couple per second), it cannot be stopped via channel because inner while loop never breaks. This PR fixes the issue.