### PR TITLE
introduce more optional features to slim down required dependency graph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,26 +11,30 @@ keywords = ["web", "framework", "http", "rest"]
 categories = ["web-programming::http-server", "web-programming::websocket"]
 
 [features]
-default = ["gzip", "brotli"]
+default = ["gzip", "brotli", "logging", "assets", "post", "session"]
 gzip = ["deflate"]
 ssl = ["tiny_http/ssl"]
 rustls = ["tiny_http/ssl-rustls"]
+logging = ["chrono"]
+assets = ["filetime", "time"]
+post = ["multipart"]
+session = ["rand"]
 
 [dependencies]
 base64 = "0.13"
 brotli = { version = "3.3.2", optional = true }
-chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
-filetime = "0.2.0"
+chrono = { version = "0.4.19", optional = true, default-features = false, features = ["clock"] }
+filetime = { version = "0.2.0", optional = true }
 deflate = { version = "1.0.0", optional = true, features = ["gzip"] }
-multipart = { version = "0.18", default-features = false, features = ["server"] }
+multipart = { version = "0.18", optional = true, default-features = false, features = ["server"] }
 percent-encoding = "2"
-rand = "0.8"
+rand = { version = "0.8", optional = true }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
 sha1 = "0.10.1"
-time = { version = "0.3.15", features = [ "local-offset" ] }
-tiny_http = "0.11.0"
+time = { version = "0.3.15", optional = true, features = [ "local-offset" ] }
+tiny_http = { version = "0.11.0", default-features = false }
 url = "2"
 threadpool = "1"
 num_cpus = "1"

--- a/src/content_encoding.rs
+++ b/src/content_encoding.rs
@@ -128,7 +128,7 @@ fn gzip(response: &mut Response) {
 
 #[cfg(not(feature = "gzip"))]
 #[inline]
-fn gzip(response: &mut Response) {}
+fn gzip(_: &mut Response) {}
 
 #[cfg(feature = "brotli")]
 fn brotli(response: &mut Response) {
@@ -147,7 +147,7 @@ fn brotli(response: &mut Response) {
 
 #[cfg(not(feature = "brotli"))]
 #[inline]
-fn brotli(response: &mut Response) {}
+fn brotli(_: &mut Response) {}
 
 #[cfg(test)]
 mod tests {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -29,7 +29,9 @@ pub use self::priority_header::priority_header_preferred;
 pub use self::priority_header::PriorityHeaderIter;
 
 pub mod json;
+#[cfg(feature = "post")]
 pub mod multipart;
+#[cfg(feature = "post")]
 pub mod post;
 
 mod accept;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -929,7 +929,7 @@ impl Request {
             .map(|pair| pair.split('=').nth(1).unwrap_or(""))
             .next()
             .map(|value| {
-                percent_encoding::percent_decode(value.replace("+", " ").as_bytes())
+                percent_encoding::percent_decode(value.replace('+', " ").as_bytes())
                     .decode_utf8_lossy()
                     .into_owned()
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,11 +59,15 @@
 extern crate base64;
 #[cfg(feature = "brotli")]
 extern crate brotli;
+#[cfg(feature = "logging")]
 extern crate chrono;
 #[cfg(feature = "gzip")]
 extern crate deflate;
+#[cfg(feature = "assets")]
 extern crate filetime;
+#[cfg(feature = "post")]
 extern crate multipart;
+#[cfg(feature = "session")]
 extern crate rand;
 extern crate serde;
 #[macro_use]
@@ -73,6 +77,7 @@ pub extern crate percent_encoding;
 extern crate serde_json;
 extern crate sha1;
 extern crate threadpool;
+#[cfg(feature = "assets")]
 extern crate time;
 extern crate tiny_http;
 pub extern crate url;
@@ -89,8 +94,11 @@ pub const DEFAULT_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::C
     .add(b'{')
     .add(b'}');
 
+#[cfg(feature = "assets")]
 pub use assets::extension_to_mime;
+#[cfg(feature = "assets")]
 pub use assets::match_assets;
+#[cfg(feature = "logging")]
 pub use log::{log, log_custom};
 pub use response::{Response, ResponseBody};
 pub use tiny_http::ReadWrite;
@@ -117,11 +125,14 @@ pub mod cgi;
 pub mod content_encoding;
 pub mod input;
 pub mod proxy;
+#[cfg(feature = "session")]
 pub mod session;
 pub mod websocket;
 
+#[cfg(feature = "assets")]
 mod assets;
 mod find_route;
+#[cfg(feature = "logging")]
 mod log;
 mod response;
 mod router;


### PR DESCRIPTION
This introduces the feature flags: logging, assets, post, session.

The goal was to slim down required dependencies in my application and the categories were chosen to make an impact on that.
Updated tiny_http to get rid of a hard chrono requirement.

A simple hello world with `default-features = false` goes from 96 to 44 dependencies and total build time in release from 30s to 15s.