### PR TITLE
Remove dependency on num_cpus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ time = { version = "0.3.15", features = [ "local-offset" ] }
 tiny_http = { version = "0.12.0", default-features = false }
 url = "2"
 threadpool = "1"
-num_cpus = "1"
 sha1_smol = "1.0.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@ extern crate rand;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate num_cpus;
 pub extern crate percent_encoding;
 extern crate serde_json;
 extern crate sha1_smol;
@@ -244,9 +243,15 @@ where
     A: ToSocketAddrs,
     F: Send + Sync + 'static + Fn(&Request) -> Response,
 {
+    let pool_size = pool_size.unwrap_or_else(|| {
+        8 * thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1)
+    });
+
     Server::new(addr, handler)
         .expect("Failed to start server")
-        .pool_size(pool_size.unwrap_or_else(|| 8 * num_cpus::get()))
+        .pool_size(pool_size)
         .run();
     panic!("The server socket closed unexpectedly")
 }


### PR DESCRIPTION
Replace the one call to `num_cpus::get()` with [`thread::available_parallelism()`](https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html) which has been stable since Rust 1.59 and has nearly identical functionality.

This allows for removing the dependency on `num_cpus` entirely.