### PR TITLE
Use sha1-smol, closes #267

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,12 @@ rand = "0.8"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-sha1 = "0.10.1"
 time = { version = "0.3.15", features = [ "local-offset" ] }
 tiny_http = { version = "0.12.0", default-features = false }
 url = "2"
 threadpool = "1"
 num_cpus = "1"
+sha1_smol = "1.0.0"
 
 [dev-dependencies]
 postgres = { version = "0.19", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ extern crate serde_derive;
 extern crate num_cpus;
 pub extern crate percent_encoding;
 extern crate serde_json;
-extern crate sha1;
+extern crate sha1_smol;
 extern crate threadpool;
 extern crate time;
 extern crate tiny_http;

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -70,7 +70,7 @@ pub use self::websocket::SendError;
 pub use self::websocket::Websocket;
 
 use base64;
-use sha1::{Digest, Sha1};
+use sha1_smol::Sha1;
 use std::borrow::Cow;
 use std::error;
 use std::fmt;
@@ -246,5 +246,5 @@ fn convert_key(input: &str) -> String {
     sha1.update(input.as_bytes());
     sha1.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
 
-    base64::encode_config(&sha1.finalize(), base64::STANDARD)
+    base64::encode_config(&sha1.digest().bytes(), base64::STANDARD)
 }


### PR DESCRIPTION
The API of sha1-smol changed a little compared to sha1, instead of a `Digest` trait, you get the hashed digest out using `.digest()` or `.hexdigest()` inherent methods.