### PR TITLE
Fix `rouille::Server`: Expose `new_ssl` on feat `rustls`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,7 +370,7 @@ where
     ///
     /// Returns an error if there was an error while creating the listening socket, for example if
     /// the port is already in use.
-    #[cfg(feature = "ssl")]
+    #[cfg(any(feature = "ssl", feature = "rustls"))]
     pub fn new_ssl<A>(
         addr: A,
         handler: F,


### PR DESCRIPTION
Since `tiny_http::Server::https` is also supported under `rustls`.