### PR TITLE
Fix typo: "starts to fail" → "fails to start"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ macro_rules! assert_or_400 {
 ///
 /// # Panic
 ///
-/// This function will panic if the server starts to fail (for example if you use a port that is
+/// This function will panic if the server fails to start (for example if you use a port that is
 /// already occupied) or if the socket is force-closed by the operating system.
 ///
 /// If you need to handle these situations, please see `Server`.


### PR DESCRIPTION
I have trouble making sense of the current phrasing, whereas switching the older of the words matches the implication of the parenthesized part.