### PR TITLE
Update to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "rouille"
 version = "3.6.2"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
 repository = "https://github.com/tomaka/rouille"
 documentation = "http://docs.rs/rouille"
 description = "High-level idiomatic web framework."

--- a/examples/database.rs
+++ b/examples/database.rs
@@ -7,17 +7,11 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-#[macro_use]
-extern crate rouille;
-extern crate postgres;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-
 use std::sync::Mutex;
 
 use postgres::{Client, NoTls, Transaction};
-
+use rouille::router;
+use rouille::try_or_400;
 use rouille::Request;
 use rouille::Response;
 
@@ -109,7 +103,7 @@ fn note_routes(request: &Request, db: &mut Transaction) -> Response {
         (GET) (/notes) => {
             // This route returns the list of notes. We perform the query and output it as JSON.
 
-            #[derive(Serialize)]
+            #[derive(serde_derive::Serialize)]
             struct Elem { id: String }
 
             let mut out = Vec::new();

--- a/examples/git-http-backend.rs
+++ b/examples/git-http-backend.rs
@@ -7,8 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-extern crate rouille;
-
 use rouille::cgi::CgiRun;
 use std::env;
 use std::io;

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -8,8 +8,6 @@
 // according to those terms.
 
 #![allow(unreachable_code)]
-#[macro_use]
-extern crate rouille;
 
 fn main() {
     println!("Now listening on localhost:8000");
@@ -29,7 +27,7 @@ fn main() {
         // the `router!` macro is an expression whose value is the `Response` built by the block
         // that was called. Since `router!` is the last piece of code of this closure, the
         // `Response` is then passed back to the `start_server` function and sent to the client.
-        router!(request,
+        rouille::router!(request,
             (GET) (/) => {
                 // If the request's URL is `/`, we jump here.
                 // This block builds a `Response` object that redirects to the `/hello/world`.

--- a/examples/login-session.rs
+++ b/examples/login-session.rs
@@ -1,7 +1,9 @@
+#![allow(dead_code)]
 #![allow(unreachable_code)]
-#[macro_use]
-extern crate rouille;
 
+use rouille::post_input;
+use rouille::router;
+use rouille::try_or_400;
 use rouille::Request;
 use rouille::Response;
 use std::collections::HashMap;
@@ -95,7 +97,7 @@ fn main() {
 fn handle_route(request: &Request, session_data: &mut Option<SessionData>) -> Response {
     // First we handle the routes that are always accessible and always the same, no matter whether
     // the user is logged in or not.
-    router!(request,
+    rouille::router!(request,
         (POST) (/login) => {
             // This is the route that is called when the user wants to log in.
 

--- a/examples/php.rs
+++ b/examples/php.rs
@@ -7,8 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-extern crate rouille;
-
 use rouille::cgi::CgiRun;
 use std::process::Command;
 

--- a/examples/reverse-proxy.rs
+++ b/examples/reverse-proxy.rs
@@ -7,8 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-extern crate rouille;
-
 fn main() {
     // This example shows how to create a reverse proxy with rouille.
 

--- a/examples/simple-form.rs
+++ b/examples/simple-form.rs
@@ -1,7 +1,8 @@
-#[macro_use]
-extern crate rouille;
-
 use std::io;
+
+use rouille::post_input;
+use rouille::router;
+use rouille::try_or_400;
 
 fn main() {
     // This example demonstrates how to handle HTML forms.

--- a/examples/static-files.rs
+++ b/examples/static-files.rs
@@ -7,8 +7,6 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-extern crate rouille;
-
 use rouille::Response;
 
 fn main() {

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -7,11 +7,10 @@
 // notice may not be copied, modified, or distributed except
 // according to those terms.
 
-#[macro_use]
-extern crate rouille;
-
 use std::thread;
 
+use rouille::router;
+use rouille::try_or_400;
 use rouille::websocket;
 use rouille::Response;
 

--- a/rouille-multipart/examples/hyper_client.rs
+++ b/rouille-multipart/examples/hyper_client.rs
@@ -1,11 +1,8 @@
-extern crate hyper;
-extern crate multipart;
-
 use hyper::client::Request;
 use hyper::method::Method;
 use hyper::net::Streaming;
 
-use multipart::client::Multipart;
+use rouille_multipart::client::Multipart;
 
 use std::io::Read;
 

--- a/rouille-multipart/examples/hyper_reqbuilder.rs
+++ b/rouille-multipart/examples/hyper_reqbuilder.rs
@@ -1,9 +1,6 @@
-extern crate hyper;
-extern crate multipart;
-
 use hyper::Client;
 
-use multipart::client::lazy::Multipart;
+use rouille_multipart::client::lazy::Multipart;
 
 fn main() {
     let mut binary = "Hello world in binary!".as_bytes();

--- a/rouille-multipart/examples/hyper_server.rs
+++ b/rouille-multipart/examples/hyper_server.rs
@@ -1,12 +1,9 @@
-extern crate hyper;
-extern crate multipart;
-
 use hyper::server::response::Response as HyperResponse;
 use hyper::server::{Handler, Request, Response, Server};
 use hyper::status::StatusCode;
-use multipart::mock::StdoutTee;
-use multipart::server::hyper::{HyperRequest, MultipartHandler, Switch};
-use multipart::server::{Entries, Multipart, SaveResult};
+use rouille_multipart::mock::StdoutTee;
+use rouille_multipart::server::hyper::{HyperRequest, MultipartHandler, Switch};
+use rouille_multipart::server::{Entries, Multipart, SaveResult};
 use std::io;
 
 struct NonMultipart;

--- a/rouille-multipart/examples/iron.rs
+++ b/rouille-multipart/examples/iron.rs
@@ -1,12 +1,9 @@
-extern crate iron;
-extern crate multipart;
-
 extern crate env_logger;
 
 use iron::prelude::*;
 use iron::status;
-use multipart::mock::StdoutTee;
-use multipart::server::{Entries, Multipart, SaveResult};
+use rouille_multipart::mock::StdoutTee;
+use rouille_multipart::server::{Entries, Multipart, SaveResult};
 use std::io::{self, Write};
 
 fn main() {

--- a/rouille-multipart/examples/iron_intercept.rs
+++ b/rouille-multipart/examples/iron_intercept.rs
@@ -1,10 +1,7 @@
-extern crate iron;
-extern crate multipart;
-
 use iron::prelude::*;
 
-use multipart::server::iron::Intercept;
-use multipart::server::Entries;
+use rouille_multipart::server::iron::Intercept;
+use rouille_multipart::server::Entries;
 
 fn main() {
     // We start with a basic request handler chain.

--- a/rouille-multipart/examples/nickel.rs
+++ b/rouille-multipart/examples/nickel.rs
@@ -1,13 +1,10 @@
-extern crate multipart;
-extern crate nickel;
-
 use nickel::status::StatusCode;
 use nickel::{Action, HttpRouter, MiddlewareResult, Nickel, Request, Response};
 use std::io::{self, Write};
 
-use multipart::mock::StdoutTee;
-use multipart::server::nickel::MultipartBody;
-use multipart::server::{Entries, SaveResult};
+use rouille_multipart::mock::StdoutTee;
+use rouille_multipart::server::nickel::MultipartBody;
+use rouille_multipart::server::{Entries, SaveResult};
 
 fn handle_multipart<'mw>(req: &mut Request, mut res: Response<'mw>) -> MiddlewareResult<'mw> {
     match (*req).multipart_body() {

--- a/rouille-multipart/examples/tiny_http.rs
+++ b/rouille-multipart/examples/tiny_http.rs
@@ -1,8 +1,5 @@
-extern crate multipart;
-extern crate tiny_http;
-
-use multipart::mock::StdoutTee;
-use multipart::server::{Entries, Multipart, SaveResult};
+use rouille_multipart::mock::StdoutTee;
+use rouille_multipart::server::{Entries, Multipart, SaveResult};
 use std::io::{self, Cursor, Write};
 use tiny_http::{Request, Response, StatusCode};
 fn main() {

--- a/rouille-multipart/src/bin/form_test.rs
+++ b/rouille-multipart/src/bin/form_test.rs
@@ -1,7 +1,4 @@
-extern crate hyper;
-extern crate multipart;
-
-use multipart::server::Multipart;
+use rouille_multipart::server::Multipart;
 
 use hyper::header::ContentType;
 use hyper::server::*;

--- a/rouille-multipart/src/client/lazy.rs
+++ b/rouille-multipart/src/client/lazy.rs
@@ -79,10 +79,6 @@ impl<'a> Into<io::Error> for LazyError<'a, io::Error> {
 }
 
 impl<'a, E: Error> Error for LazyError<'a, E> {
-    fn description(&self) -> &str {
-        self.error.description()
-    }
-
     fn cause(&self) -> Option<&dyn Error> {
         Some(&self.error)
     }

--- a/rouille-multipart/src/local_test.rs
+++ b/rouille-multipart/src/local_test.rs
@@ -4,9 +4,9 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-use mock::{ClientRequest, HttpBuffer};
+use crate::mock::{ClientRequest, HttpBuffer};
 
-use server::{FieldHeaders, MultipartField, ReadEntry};
+use crate::server::{FieldHeaders, MultipartField, ReadEntry};
 
 use mime::Mime;
 
@@ -226,7 +226,7 @@ impl fmt::Debug for PrintHex {
 
 macro_rules! do_test (
     ($client_test:ident, $server_test:ident) => (
-        ::init_log();
+        crate::init_log();
 
         info!("Client Test: {:?} Server Test: {:?}", stringify!($client_test),
               stringify!($server_test));
@@ -344,7 +344,7 @@ fn gen_bytes() -> Vec<u8> {
 }
 
 fn test_client(test_fields: &TestFields) -> HttpBuffer {
-    use client::Multipart;
+    use crate::client::Multipart;
 
     let request = ClientRequest::default();
 
@@ -392,7 +392,7 @@ fn test_client(test_fields: &TestFields) -> HttpBuffer {
 }
 
 fn test_client_lazy(test_fields: &TestFields) -> HttpBuffer {
-    use client::lazy::Multipart;
+    use crate::client::lazy::Multipart;
 
     let mut multipart = Multipart::new();
 
@@ -441,7 +441,7 @@ fn test_client_lazy(test_fields: &TestFields) -> HttpBuffer {
 }
 
 fn test_server(buf: HttpBuffer, fields: &mut TestFields) {
-    use server::Multipart;
+    use crate::server::Multipart;
 
     let server_buf = buf.for_server();
 
@@ -461,7 +461,7 @@ fn test_server(buf: HttpBuffer, fields: &mut TestFields) {
 }
 
 fn test_server_entry_api(buf: HttpBuffer, fields: &mut TestFields) {
-    use server::Multipart;
+    use crate::server::Multipart;
 
     let server_buf = buf.for_server();
 

--- a/rouille-multipart/src/server/boundary.rs
+++ b/rouille-multipart/src/server/boundary.rs
@@ -310,7 +310,7 @@ mod test {
 
     #[test]
     fn test_boundary() {
-        ::init_log();
+        crate::init_log();
 
         debug!("Testing boundary (no split)");
 
@@ -356,7 +356,7 @@ mod test {
 
     #[test]
     fn test_split_boundary() {
-        ::init_log();
+        crate::init_log();
 
         debug!("Testing boundary (split)");
 
@@ -406,7 +406,7 @@ mod test {
 
     #[test]
     fn test_empty_body() {
-        ::init_log();
+        crate::init_log();
 
         // empty body contains closing boundary only
         let mut body: &[u8] = b"--boundary--";
@@ -428,7 +428,7 @@ mod test {
 
     #[test]
     fn test_leading_crlf() {
-        ::init_log();
+        crate::init_log();
 
         let mut body: &[u8] = b"\r\n\r\n--boundary\r\n\
                          asdf1234\
@@ -455,7 +455,7 @@ mod test {
 
     #[test]
     fn test_trailing_crlf() {
-        ::init_log();
+        crate::init_log();
 
         let mut body: &[u8] = b"--boundary\r\n\
                          asdf1234\
@@ -499,7 +499,7 @@ mod test {
     // https://github.com/abonander/multipart/issues/93#issuecomment-343610587
     #[test]
     fn test_trailing_lflf() {
-        ::init_log();
+        crate::init_log();
 
         let mut body: &[u8] = b"--boundary\r\n\
                          asdf1234\
@@ -542,7 +542,7 @@ mod test {
     // https://github.com/abonander/multipart/issues/104
     #[test]
     fn test_unterminated_body() {
-        ::init_log();
+        crate::init_log();
 
         let mut body: &[u8] = b"--boundary\r\n\
                          asdf1234\

--- a/rouille-multipart/src/server/mod.rs
+++ b/rouille-multipart/src/server/mod.rs
@@ -203,7 +203,7 @@ pub trait HttpRequest {
 
 #[test]
 fn issue_104() {
-    ::init_log();
+    crate::init_log();
 
     use std::io::Cursor;
 
@@ -226,7 +226,7 @@ fn issue_104() {
 
 #[test]
 fn issue_114() {
-    ::init_log();
+    crate::init_log();
 
     fn consume_all<R: BufRead>(mut rdr: R) {
         loop {

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -13,8 +13,8 @@ use std::path::Path;
 use filetime;
 use time;
 
-use Request;
-use Response;
+use crate::Request;
+use crate::Response;
 
 /// Searches inside `path` for a file that matches the given request. If a file is found,
 /// returns a `Response` that would serve this file if returned. If no file is found, a 404

--- a/src/cgi.rs
+++ b/src/cgi.rs
@@ -46,9 +46,9 @@ use std::io::Read;
 use std::process::Command;
 use std::process::Stdio;
 
-use Request;
-use Response;
-use ResponseBody;
+use crate::Request;
+use crate::Response;
+use crate::ResponseBody;
 
 /// Error that can happen when parsing the JSON input.
 #[derive(Debug)]

--- a/src/content_encoding.rs
+++ b/src/content_encoding.rs
@@ -25,9 +25,9 @@
 //!     content_encoding::apply(&request, response)
 //! }
 //! ```
-use input;
-use Request;
-use Response;
+use crate::input;
+use crate::Request;
+use crate::Response;
 
 /// Applies content encoding to the response.
 ///
@@ -107,10 +107,10 @@ fn response_is_text(response: &Response) -> bool {
 
 #[cfg(feature = "gzip")]
 fn gzip(response: &mut Response) {
+    use crate::ResponseBody;
     use deflate::deflate_bytes_gzip;
     use std::io;
     use std::mem;
-    use ResponseBody;
 
     response
         .headers
@@ -132,9 +132,9 @@ fn gzip(response: &mut Response) {}
 
 #[cfg(feature = "brotli")]
 fn brotli(response: &mut Response) {
+    use crate::ResponseBody;
     use brotli::enc::reader::CompressorReader;
     use std::mem;
-    use ResponseBody;
 
     response
         .headers
@@ -151,9 +151,9 @@ fn brotli(response: &mut Response) {}
 
 #[cfg(test)]
 mod tests {
-    use content_encoding;
-    use Request;
-    use Response;
+    use crate::content_encoding;
+    use crate::Request;
+    use crate::Response;
 
     // TODO: more tests for encoding stuff
     #[test]

--- a/src/find_route.rs
+++ b/src/find_route.rs
@@ -15,9 +15,7 @@
 /// # Example
 ///
 /// ```
-/// # #[macro_use] extern crate rouille;
-/// # fn main() {
-/// use rouille::{Request, Response};
+/// use rouille::{Request, Response, find_route};
 ///
 /// fn handle_request_a(_: &Request) -> Response {
 /// # panic!()
@@ -45,9 +43,7 @@
 ///     handle_request_b(request),
 ///     handle_request_c(request)
 /// );
-/// # }
 /// ```
-///
 #[macro_export]
 macro_rules! find_route {
     ($($handler:expr),+) => ({

--- a/src/input/accept.rs
+++ b/src/input/accept.rs
@@ -28,9 +28,9 @@
 /// # Basic example
 ///
 /// ```
-/// # #[macro_use] extern crate rouille;
 /// use rouille::Request;
 /// use rouille::Response;
+/// use rouille::accept;
 ///
 /// fn handle(request: &Request) -> Response {
 ///     accept!(request,
@@ -38,15 +38,14 @@
 ///         "text/plain" => Response::text("Hello world"),
 ///     )
 /// }
-/// # fn main() {}
 /// ```
 ///
 /// # Example with a default handler
 ///
 /// ```
-/// # #[macro_use] extern crate rouille;
 /// use rouille::Request;
 /// use rouille::Response;
+/// use rouille::accept;
 ///
 /// fn handle(request: &Request) -> Response {
 ///     accept!(request,
@@ -55,7 +54,6 @@
 ///         "*/*" => Response::empty_406()
 ///     )
 /// }
-/// # fn main() {}
 /// ```
 #[macro_export]
 macro_rules! accept {
@@ -92,7 +90,7 @@ macro_rules! accept {
 
 #[cfg(test)]
 mod tests {
-    use Request;
+    use crate::Request;
 
     #[test]
     fn basic() {

--- a/src/input/basic_http_auth.rs
+++ b/src/input/basic_http_auth.rs
@@ -18,7 +18,8 @@
 //!   [the `plain_text_body` function](fn.plain_text_body.html).
 
 use base64::{prelude::BASE64_STANDARD, Engine as _};
-use Request;
+
+use crate::Request;
 
 /// Credentials returned by `basic_http_auth`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -107,7 +108,7 @@ pub fn basic_http_auth(request: &Request) -> Option<HttpAuthCredentials> {
 mod test {
     use super::basic_http_auth;
     use super::HttpAuthCredentials;
-    use Request;
+    use crate::Request;
 
     #[test]
     fn basic_http_auth_no_header() {

--- a/src/input/cookies.rs
+++ b/src/input/cookies.rs
@@ -17,8 +17,8 @@
 //! - In order to read a plain text body, see
 //!   [the `plain_text_body` function](fn.plain_text_body.html).
 
+use crate::Request;
 use std::str::Split;
-use Request;
 
 /// Attempts to parse the list of cookies from the request.
 ///
@@ -38,7 +38,7 @@ use Request;
 /// ```
 // TODO: should an error be returned if the header is malformed?
 // TODO: be less tolerant to what is accepted?
-pub fn cookies(request: &Request) -> CookiesIter {
+pub fn cookies(request: &Request) -> CookiesIter<'_> {
     let header = request.header("Cookie").unwrap_or("");
 
     CookiesIter {
@@ -90,7 +90,7 @@ impl<'a> Iterator for CookiesIter<'a> {
 #[cfg(test)]
 mod test {
     use super::cookies;
-    use Request;
+    use crate::Request;
 
     #[test]
     fn no_cookie() {

--- a/src/input/json.rs
+++ b/src/input/json.rs
@@ -15,14 +15,10 @@
 //! # Example
 //!
 //! ```
-//! # extern crate serde;
-//! # #[macro_use] extern crate serde_derive;
-//! # #[macro_use] extern crate rouille;
-//! # use rouille::{Request, Response};
-//! # fn main() {}
+//! use rouille::{Request, Response, try_or_400};
 //!
 //! fn route_handler(request: &Request) -> Response {
-//!     #[derive(Deserialize)]
+//!     #[derive(serde_derive::Deserialize)]
 //!     struct Json {
 //!         field1: String,
 //!         field2: i32,
@@ -32,14 +28,14 @@
 //!     Response::text(format!("field1's value is {}", json.field1))
 //! }
 //! ```
-//!
 
 use serde;
 use serde_json;
 use std::error;
 use std::fmt;
 use std::io::Error as IoError;
-use Request;
+
+use crate::Request;
 
 /// Error that can happen when parsing the JSON input.
 #[derive(Debug)]
@@ -103,14 +99,10 @@ impl fmt::Display for JsonError {
 /// # Example
 ///
 /// ```
-/// # extern crate serde;
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate rouille;
-/// # use rouille::{Request, Response};
-/// fn main() {}
+/// use rouille::{Request, Response, try_or_400};
 ///
 /// fn route_handler(request: &Request) -> Response {
-///     #[derive(Deserialize)]
+///     #[derive(serde_derive::Deserialize)]
 ///     struct Json {
 ///         field1: String,
 ///         field2: i32,

--- a/src/input/multipart.rs
+++ b/src/input/multipart.rs
@@ -15,14 +15,14 @@
 use std::error;
 use std::fmt;
 
-use Request;
-use RequestBody;
-
 use rouille_multipart::server::Multipart as InnerMultipart;
 
 // TODO: provide wrappers around these
 pub use rouille_multipart::server::MultipartData;
 pub use rouille_multipart::server::MultipartField;
+
+use crate::Request;
+use crate::RequestBody;
 
 /// Error that can happen when decoding multipart data.
 #[derive(Clone, Debug)]
@@ -55,7 +55,7 @@ impl fmt::Display for MultipartError {
 }
 
 /// Attempts to decode the content of the request as `multipart/form-data` data.
-pub fn get_multipart_input(request: &Request) -> Result<Multipart, MultipartError> {
+pub fn get_multipart_input(request: &Request) -> Result<Multipart<'_>, MultipartError> {
     let boundary = match multipart_boundary(request) {
         Some(b) => b,
         None => return Err(MultipartError::WrongContentType),

--- a/src/input/plain.rs
+++ b/src/input/plain.rs
@@ -11,7 +11,8 @@ use std::error;
 use std::fmt;
 use std::io::Error as IoError;
 use std::io::Read;
-use Request;
+
+use crate::Request;
 
 /// Error that can happen when parsing the request body as plain text.
 #[derive(Debug)]
@@ -79,9 +80,8 @@ impl fmt::Display for PlainTextError {
 /// # Example
 ///
 /// ```
-/// # #[macro_use] extern crate rouille;
-/// # use rouille::{Request, Response};
-/// # fn main() {}
+/// use rouille::{Request, Response, try_or_400};
+///
 /// fn route_handler(request: &Request) -> Response {
 ///     let text = try_or_400!(rouille::input::plain_text_body(request));
 ///     Response::text(format!("you sent: {}", text))
@@ -138,7 +138,7 @@ mod test {
     use super::plain_text_body;
     use super::plain_text_body_with_limit;
     use super::PlainTextError;
-    use Request;
+    use crate::Request;
 
     #[test]
     fn ok() {

--- a/src/input/post.rs
+++ b/src/input/post.rs
@@ -12,9 +12,10 @@
 //! In order to parse the body of a request, you can use the `post_input!` macro.
 //!
 //! ```
-//! # #[macro_use] extern crate rouille;
 //! use rouille::Request;
 //! use rouille::Response;
+//! use rouille::try_or_400;
+//! use rouille::post_input;
 //!
 //! fn handle_request(request: &Request) -> Response {
 //!     let input = try_or_400!(post_input!(request, {
@@ -24,7 +25,6 @@
 //!
 //!     Response::text(format!("the value of field1 is: {}", input.field1))
 //! }
-//! # fn main() {}
 //! ```
 //!
 //! In this example, the macro will read the body of the request and try to find fields whose
@@ -73,9 +73,10 @@
 //! Example:
 //!
 //! ```
-//! # #[macro_use] extern crate rouille;
 //! use rouille::Request;
 //! use rouille::Response;
+//! use rouille::post_input;
+//! use rouille::try_or_400;
 //! use rouille::input::post::BufferedFile;
 //!
 //! fn handle_request(request: &Request) -> Response {
@@ -85,7 +86,6 @@
 //!
 //!     Response::text("everything ok")
 //! }
-//! # fn main() {}
 //! ```
 //!
 //! # How it works internally
@@ -101,7 +101,7 @@
 //! `from_file` method. You should return `PostFieldError::WrongFieldType` if you're
 //! expecting a file and `from_field` was called, or vice-versa.
 
-use Request;
+use crate::Request;
 
 use std::borrow::Cow;
 use std::error;
@@ -698,9 +698,9 @@ pub fn raw_urlencoded_post_input(request: &Request) -> Result<Vec<(String, Strin
 
 #[cfg(test)]
 mod tests {
-    use input::post::PostError;
-    use input::post::PostFieldError;
-    use Request;
+    use crate::input::post::PostError;
+    use crate::input::post::PostFieldError;
+    use crate::Request;
 
     #[test]
     fn basic_int() {
@@ -837,6 +837,7 @@ mod tests {
             b"field=value".to_vec(),
         );
 
+        #[allow(dead_code)]
         let input = post_input!(&request, { field: String });
 
         match input {
@@ -880,6 +881,7 @@ mod tests {
             b"field=12&field=58".to_vec(),
         );
 
+        #[allow(dead_code)]
         let input = post_input!(&request, { field: u32 });
 
         match input {
@@ -949,6 +951,7 @@ mod tests {
             b"field=12&field=800".to_vec(),
         );
 
+        #[allow(dead_code)]
         let input = post_input!(&request, {
             field: Vec<u8>
         });
@@ -1000,6 +1003,7 @@ mod tests {
             b"wrong_field=value".to_vec(),
         );
 
+        #[allow(dead_code)]
         let input = post_input!(&request, { field: String });
 
         match input {
@@ -1092,6 +1096,7 @@ mod tests {
             b"field=12foo".to_vec(),
         );
 
+        #[allow(dead_code)]
         let input = post_input!(&request, { field: u32 });
 
         match input {
@@ -1141,6 +1146,7 @@ mod tests {
             b"field=800".to_vec(),
         );
 
+        #[allow(dead_code)]
         let input = post_input!(&request, { field: u8 });
 
         match input {
@@ -1169,6 +1175,7 @@ mod tests {
 
         let _ = request.data();
 
+        #[allow(dead_code)]
         let input = post_input!(&request, { field: u8 });
 
         match input {
@@ -1193,6 +1200,7 @@ mod tests {
             b"field=\xc3\x28".to_vec(),
         );
 
+        #[allow(dead_code)]
         let input = post_input!(&request, { field: String });
 
         match input {

--- a/src/input/priority_header.rs
+++ b/src/input/priority_header.rs
@@ -96,7 +96,7 @@ where
 /// assert_eq!(iter.next(), None);
 /// ```
 #[inline]
-pub fn parse_priority_header(input: &str) -> PriorityHeaderIter {
+pub fn parse_priority_header(input: &str) -> PriorityHeaderIter<'_> {
     PriorityHeaderIter {
         iter: input.split(','),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,25 +56,8 @@
 
 #![deny(unsafe_code)]
 
-extern crate base64;
-#[cfg(feature = "brotli")]
-extern crate brotli;
-extern crate chrono;
-#[cfg(feature = "gzip")]
-extern crate deflate;
-extern crate filetime;
-extern crate rand;
-extern crate rouille_multipart;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-pub extern crate percent_encoding;
-extern crate serde_json;
-extern crate sha1_smol;
-extern crate threadpool;
-extern crate time;
-extern crate tiny_http;
-pub extern crate url;
+pub use percent_encoding;
+pub use url;
 
 // https://github.com/servo/rust-url/blob/e121d8d0aafd50247de5f5310a227ecb1efe6ffe/percent_encoding/lib.rs#L126
 pub const DEFAULT_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
@@ -145,10 +128,11 @@ macro_rules! try_or_404 {
 /// # Example
 ///
 /// ```
-/// # #[macro_use] extern crate rouille;
-/// # fn main() {
 /// use rouille::Request;
 /// use rouille::Response;
+/// use rouille::post_input;
+/// use rouille::assert_or_400;
+/// use rouille::try_or_400;
 ///
 /// fn handle_something(request: &Request) -> Response {
 ///     let data = try_or_400!(post_input!(request, {
@@ -159,7 +143,6 @@ macro_rules! try_or_404 {
 ///     assert_or_400!(data.field1 >= 2);
 ///     Response::text("hello")
 /// }
-/// # }
 /// ```
 #[macro_export]
 macro_rules! assert_or_400 {
@@ -945,7 +928,7 @@ impl Request {
 
     /// Returns a list of all the headers of the request.
     #[inline]
-    pub fn headers(&self) -> HeadersIter {
+    pub fn headers(&self) -> HeadersIter<'_> {
         HeadersIter {
             iter: self.headers.iter(),
         }
@@ -1006,7 +989,7 @@ impl Request {
     ///     }
     /// }
     /// ```
-    pub fn data(&self) -> Option<RequestBody> {
+    pub fn data(&self) -> Option<RequestBody<'_>> {
         let reader = self.data.lock().unwrap().take();
         reader.map(|r| RequestBody {
             body: r,
@@ -1072,7 +1055,7 @@ impl<'a> Read for RequestBody<'a> {
 
 #[cfg(test)]
 mod tests {
-    use Request;
+    use crate::Request;
 
     #[test]
     fn header() {

--- a/src/log.rs
+++ b/src/log.rs
@@ -14,8 +14,8 @@ use std::time::Instant;
 
 use chrono;
 
-use Request;
-use Response;
+use crate::Request;
+use crate::Response;
 
 /// Adds a log entry to the given writer for each request.
 ///
@@ -85,11 +85,8 @@ where
 /// # Example
 ///
 /// ```
-/// #[macro_use] extern crate log;
-/// extern crate chrono;
-/// # extern crate rouille;
+/// use log::{error, info};
 /// use rouille::{Request, Response};
-///
 ///
 /// fn handle(request: &Request) -> Response {
 ///     let now = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S%.6f");
@@ -103,8 +100,6 @@ where
 ///         Response::text("hello world")
 ///     })
 /// }
-/// #
-/// # fn main() { }
 /// ```
 pub fn log_custom<L, E, F>(req: &Request, log_ok_f: L, log_err_f: E, handler: F) -> Response
 where

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -70,9 +70,9 @@ use std::net::TcpStream;
 use std::net::ToSocketAddrs;
 use std::time::Duration;
 
-use Request;
-use Response;
-use ResponseBody;
+use crate::Request;
+use crate::Response;
+use crate::ResponseBody;
 
 /// Error that can happen when dispatching the request to another server.
 #[derive(Debug)]

--- a/src/response.rs
+++ b/src/response.rs
@@ -16,8 +16,9 @@ use std::fs::File;
 use std::io;
 use std::io::Cursor;
 use std::io::Read;
-use Request;
-use Upgrade;
+
+use crate::Request;
+use crate::Upgrade;
 
 /// Contains a prototype of a response.
 ///
@@ -357,13 +358,9 @@ impl Response {
     /// # Example
     ///
     /// ```
-    /// extern crate serde;
-    /// #[macro_use] extern crate serde_derive;
-    /// #[macro_use] extern crate rouille;
     /// use rouille::Response;
-    /// # fn main() {
     ///
-    /// #[derive(Serialize)]
+    /// #[derive(serde_derive::Serialize)]
     /// struct MyStruct {
     ///     field1: String,
     ///     field2: i32,
@@ -371,7 +368,6 @@ impl Response {
     ///
     /// let response = Response::json(&MyStruct { field1: "hello".to_owned(), field2: 5 });
     /// // The Response will contain something like `{ field1: "hello", field2: 5 }`
-    /// # }
     /// ```
     #[inline]
     pub fn json<T>(content: &T) -> Response
@@ -867,7 +863,7 @@ impl ResponseBody {
 
 #[cfg(test)]
 mod tests {
-    use Response;
+    use crate::Response;
 
     #[test]
     fn unique_header_adds() {

--- a/src/router.rs
+++ b/src/router.rs
@@ -12,9 +12,8 @@
 /// # Example
 ///
 /// ```no_run
-/// # #[macro_use] extern crate rouille; fn main() {
 /// # let request: rouille::Request = unsafe { std::mem::uninitialized() };
-/// let _result = router!(request,
+/// let _result = rouille::router!(request,
 ///     // first route
 ///     (GET) (/) => {
 ///         12
@@ -30,7 +29,6 @@
 ///     // default route
 ///     _ => 5
 /// );
-/// # }
 /// ```
 ///
 /// # Details
@@ -296,6 +294,7 @@ macro_rules! router {
             let pat_end = url.find('/').unwrap_or(url.len());
             let rest_url = &url[pat_end..];
 
+            #[allow(irrefutable_let_patterns, reason = "`.parse()` to `String` params can't error")]
             if let Ok($p) = $crate::percent_encoding::percent_decode(url[0 .. pat_end].as_bytes())
                 .decode_utf8_lossy().parse() {
                 let $p: $t = $p;
@@ -352,7 +351,7 @@ macro_rules! router {
 #[allow(unused_variables)]
 #[cfg(test)]
 mod tests {
-    use Request;
+    use crate::Request;
 
     // -- old-style tests --
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -40,9 +40,9 @@ use std::borrow::Cow;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 
-use input;
-use Request;
-use Response;
+use crate::input;
+use crate::Request;
+use crate::Response;
 
 pub fn session<'r, F>(request: &'r Request, cookie_name: &str, timeout_s: u64, inner: F) -> Response
 where

--- a/src/try_or_400.rs
+++ b/src/try_or_400.rs
@@ -12,16 +12,19 @@
 
 use std::error::Error;
 
+use serde_derive::Serialize;
+
 /// This macro assumes that the current function returns a `Response` and takes a `Result`.
 /// If the expression you pass to the macro is an error, then a 400 response is returned.
 ///
 /// # Example
 ///
 /// ```
-/// # #[macro_use] extern crate rouille;
-/// # fn main() {
 /// use rouille::Request;
 /// use rouille::Response;
+/// use rouille::post_input;
+/// use rouille::assert_or_400;
+/// use rouille::try_or_400;
 ///
 /// fn handle_something(request: &Request) -> Response {
 ///     let data = try_or_400!(post_input!(request, {
@@ -31,7 +34,6 @@ use std::error::Error;
 ///
 ///     Response::text("hello")
 /// }
-/// # }
 /// ```
 #[macro_export]
 macro_rules! try_or_400 {

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -47,14 +47,13 @@
 //! # Example
 //!
 //! ```
-//! # #[macro_use] extern crate rouille;
 //! use std::sync::Mutex;
 //! use std::sync::mpsc::Receiver;
 //!
 //! use rouille::Request;
 //! use rouille::Response;
+//! use rouille::try_or_400;
 //! use rouille::websocket;
-//! # fn main() {}
 //!
 //! fn handle_request(request: &Request, websockets: &Mutex<Vec<Receiver<websocket::Websocket>>>)
 //!                   -> Response
@@ -77,8 +76,8 @@ use std::fmt;
 use std::sync::mpsc;
 use std::vec::IntoIter as VecIntoIter;
 
-use Request;
-use Response;
+use crate::Request;
+use crate::Response;
 
 mod low_level;
 #[allow(clippy::module_inception)]

--- a/src/websocket/websocket.rs
+++ b/src/websocket/websocket.rs
@@ -11,10 +11,10 @@ use std::io;
 use std::io::Write;
 use std::mem;
 use std::sync::mpsc::Sender;
-use ReadWrite;
-use Upgrade;
 
-use websocket::low_level;
+use crate::websocket::low_level;
+use crate::ReadWrite;
+use crate::Upgrade;
 
 /// A successful websocket. An open channel of communication. Implements `Read` and `Write`.
 pub struct Websocket {


### PR DESCRIPTION
Rouille does not currently specify an edition. Set it to 2021 and update to newer idioms, including:

* Remove unneeded `extern crate`
* Remove `fn main() { /* ... */ }` in doctests
* Replace `#[macro_use]` with direct imports