### PR TITLE
Set a MSRV to 1.82 and test it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,3 +62,16 @@ jobs:
         with:
           command: test
           args: --features ${{ matrix.features }}
+
+  msrv:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@master
+      - name: Install Rust
+        run: |
+          msrv="$(cargo metadata --format-version=1 |
+            jq -r '.packages[] | select(.name == "rouille").rust_version'
+          )"
+          rustup update "$msrv" && rustup default "$msrv"
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "High-level idiomatic web framework."
 readme = "README.md"
 keywords = ["web", "framework", "http", "rest"]
 categories = ["web-programming::http-server", "web-programming::websocket"]
+rust-version = "1.82"
 
 [features]
 default = ["gzip", "brotli"]


### PR DESCRIPTION
1.82 seems to be the lowest version supported by dependencies; in particular, the latest version of `writeable` requires 1.81, and `icu_properties_data` requires 1.82.