### PR TITLE
fix (post): uploading plain text files

### DIFF
--- a/src/input/post.rs
+++ b/src/input/post.rs
@@ -596,7 +596,7 @@ macro_rules! post_input {
                                 let config = $config;
                             )*
 
-                            if multipart_entry.is_text() {
+                            if multipart_entry.headers.filename.is_none() {
                                 let mut text = String::new();
                                 multipart_entry.data.read_to_string(&mut text)?;
                                 let decoded = match DecodePostField::from_field(config, &text) {


### PR DESCRIPTION
closes #291

We were using `mutipart_field.is_text()` to branch between parsing it as a text field vs a file, but text files pass this check and then subsequently fail to parse as a text field (rightly so).

This change checks for the existence of a filename instead to decide whether to parse the field as a file or text field.